### PR TITLE
Add database backup and restore (kiqr db dump/list/restore)

### DIFF
--- a/src/commands/db/dump.tsx
+++ b/src/commands/db/dump.tsx
@@ -1,0 +1,86 @@
+import {useState, useRef} from 'react';
+import {Box, Text, useApp} from 'ink';
+import {createGzip} from 'node:zlib';
+import StepRunner from '../../components/StepRunner.js';
+import type {Step} from '../../components/StepRunner.js';
+import {readProjectConfig} from '../../lib/config.js';
+import {getProjectRuntimeDir, getProjectBackupsDir} from '../../lib/paths.js';
+import {getMachineHostname} from '../../lib/hostname.js';
+import {createBackupStorage} from '../../lib/backup-storage.js';
+import {encodeBackupId} from '../../lib/backups.js';
+import {spawnWpCli} from '../../lib/wpcli.js';
+import type {BackupRecord} from '../../lib/backup-storage.js';
+import path from 'node:path';
+
+export const description = 'Create a compressed SQL backup of the database';
+
+export default function DbDump() {
+  const {exit} = useApp();
+  const [complete, setComplete] = useState(false);
+  const ref = useRef<{record: BackupRecord | null}>({record: null});
+
+  const steps: Step[] = [
+    {
+      label: 'Creating database backup...',
+      run: async () => {
+        const pc = readProjectConfig();
+        if (!pc) {
+          throw new Error('This project is not initialized. Run "kiqr init" first.');
+        }
+        const composePath = path.join(getProjectRuntimeDir(pc.project_id), 'compose.yaml');
+        const storage = createBackupStorage(getProjectBackupsDir(pc.project_id));
+        const createdAt = new Date();
+        const id = encodeBackupId(createdAt);
+
+        const child = spawnWpCli(composePath, ['wp', 'db', 'export', '-']);
+        const stderrChunks: Buffer[] = [];
+        child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+
+        const gzipped = child.stdout.pipe(createGzip());
+
+        const [record] = await Promise.all([
+          storage.save(gzipped, {
+            projectId: pc.project_id,
+            host: getMachineHostname(),
+            createdAt,
+            id,
+          }),
+          new Promise<void>((resolve, reject) => {
+            child.on('error', reject);
+            child.on('close', (code) => {
+              if (code === 0) resolve();
+              else {
+                const msg = Buffer.concat(stderrChunks).toString().trim();
+                reject(new Error(`wp db export failed (exit ${code}): ${msg || 'no output'}`));
+              }
+            });
+          }),
+        ]);
+
+        ref.current.record = record;
+      },
+    },
+  ];
+
+  return (
+    <Box flexDirection="column">
+      <StepRunner
+        steps={steps}
+        onComplete={() => {
+          setComplete(true);
+          setTimeout(() => exit(), 100);
+        }}
+        onError={() => setTimeout(() => exit(new Error()), 100)}
+      />
+      {complete && ref.current.record && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color="green">Backup created.</Text>
+          <Text> </Text>
+          <Text>ID: <Text bold color="cyan">{ref.current.record.id}</Text></Text>
+          <Text>File: <Text dimColor>{ref.current.record.filename}</Text></Text>
+          <Text dimColor>Restore with: kiqr db restore {ref.current.record.id}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/commands/db/index.tsx
+++ b/src/commands/db/index.tsx
@@ -1,0 +1,17 @@
+import {Box, Text} from 'ink';
+
+export const description = 'Database backup and restore';
+
+export default function DbIndex() {
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      <Text bold>Kiqr DB</Text>
+      <Text dimColor>Backup and restore the project database</Text>
+      <Text> </Text>
+      <Text>Commands:</Text>
+      <Text>  <Text bold>kiqr db dump</Text>           Create a compressed SQL backup</Text>
+      <Text>  <Text bold>kiqr db list</Text>           List available backups</Text>
+      <Text>  <Text bold>kiqr db restore &lt;id&gt;</Text>    Restore from a backup</Text>
+    </Box>
+  );
+}

--- a/src/commands/db/list.tsx
+++ b/src/commands/db/list.tsx
@@ -1,0 +1,80 @@
+import {useEffect, useState} from 'react';
+import {Box, Text, useApp} from 'ink';
+import {readProjectConfig} from '../../lib/config.js';
+import {getProjectBackupsDir} from '../../lib/paths.js';
+import {createBackupStorage} from '../../lib/backup-storage.js';
+import type {BackupRecord} from '../../lib/backup-storage.js';
+
+export const description = 'List available database backups';
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+export default function DbList() {
+  const {exit} = useApp();
+  const [rows, setRows] = useState<BackupRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const pc = readProjectConfig();
+      if (!pc) {
+        setError('This project is not initialized. Run "kiqr init" first.');
+        setTimeout(() => exit(new Error()), 100);
+        return;
+      }
+      const storage = createBackupStorage(getProjectBackupsDir(pc.project_id));
+      try {
+        const list = await storage.list();
+        setRows(list);
+        setTimeout(() => exit(), 100);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setTimeout(() => exit(new Error()), 100);
+      }
+    })();
+  }, []);
+
+  if (error) return <Text color="red">{error}</Text>;
+  if (!rows) return <Text dimColor>Loading backups...</Text>;
+  if (rows.length === 0) {
+    return (
+      <Box flexDirection="column" paddingTop={1}>
+        <Text dimColor>No backups yet.</Text>
+        <Text dimColor>Create one with: kiqr db dump</Text>
+      </Box>
+    );
+  }
+
+  const idW = Math.max(2, ...rows.map((r) => r.id.length));
+  const fnW = Math.max(8, ...rows.map((r) => r.filename.length));
+  const szW = Math.max(4, ...rows.map((r) => formatBytes(r.sizeBytes).length));
+
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      <Text bold>
+        {pad('id', idW)}  {pad('filename', fnW)}  {pad('size', szW)}  date
+      </Text>
+      <Text dimColor>
+        {'-'.repeat(idW)}  {'-'.repeat(fnW)}  {'-'.repeat(szW)}  {'-'.repeat(23)}
+      </Text>
+      {rows.map((r) => (
+        <Text key={r.id}>
+          <Text color="cyan">{pad(r.id, idW)}</Text>  {pad(r.filename, fnW)}  {pad(formatBytes(r.sizeBytes), szW)}  {formatDate(r.createdAt)}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/commands/db/restore.tsx
+++ b/src/commands/db/restore.tsx
@@ -1,0 +1,272 @@
+import {useState, useRef} from 'react';
+import {Box, Text, useApp} from 'ink';
+import {ConfirmInput, TextInput} from '@inkjs/ui';
+import {createGunzip, createGzip} from 'node:zlib';
+import zod from 'zod';
+import {argument} from 'pastel';
+import {readProjectConfig} from '../../lib/config.js';
+import {getProjectRuntimeDir, getProjectBackupsDir} from '../../lib/paths.js';
+import {getMachineHostname} from '../../lib/hostname.js';
+import {createBackupStorage} from '../../lib/backup-storage.js';
+import {encodeBackupId} from '../../lib/backups.js';
+import {spawnWpCli, isWordPressInstalled} from '../../lib/wpcli.js';
+import StepRunner from '../../components/StepRunner.js';
+import type {Step} from '../../components/StepRunner.js';
+import type {BackupRecord, BackupStorage} from '../../lib/backup-storage.js';
+import path from 'node:path';
+
+export const description = 'Restore the database from a backup';
+
+export const args = zod.tuple([
+  zod.string().describe(
+    argument({name: 'id', description: 'Backup id (from `kiqr db list`)'}),
+  ),
+]);
+
+type Props = {args: zod.infer<typeof args>};
+
+type Phase =
+  | 'loading'
+  | 'ask-safety-backup'
+  | 'running-safety-backup'
+  | 'ask-captcha'
+  | 'running-restore'
+  | 'done'
+  | 'error';
+
+function generateChallenge() {
+  const a = Math.floor(Math.random() * 40) + 10;
+  const b = Math.floor(Math.random() * 40) + 10;
+  return {a, b, answer: a + b};
+}
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+async function runDump(
+  composePath: string,
+  storage: BackupStorage,
+  projectId: string,
+): Promise<BackupRecord> {
+  const createdAt = new Date();
+  const id = encodeBackupId(createdAt);
+  const child = spawnWpCli(composePath, ['wp', 'db', 'export', '-']);
+  const stderrChunks: Buffer[] = [];
+  child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+  const gzipped = child.stdout.pipe(createGzip());
+  const [record] = await Promise.all([
+    storage.save(gzipped, {projectId, host: getMachineHostname(), createdAt, id}),
+    new Promise<void>((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`wp db export failed (exit ${code}): ${Buffer.concat(stderrChunks).toString().trim()}`));
+      });
+    }),
+  ]);
+  return record;
+}
+
+async function runRestore(composePath: string, record: BackupRecord, storage: BackupStorage): Promise<void> {
+  const child = spawnWpCli(composePath, ['wp', 'db', 'import', '-']);
+  const stderrChunks: Buffer[] = [];
+  child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+  const src = storage.openRead(record).pipe(createGunzip());
+  src.pipe(child.stdin);
+  await new Promise<void>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`wp db import failed (exit ${code}): ${Buffer.concat(stderrChunks).toString().trim()}`));
+    });
+  });
+}
+
+export default function DbRestore({args}: Props) {
+  const {exit} = useApp();
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const [wrong, setWrong] = useState(false);
+  const ref = useRef<{
+    record: BackupRecord | null;
+    composePath: string;
+    storage: BackupStorage | null;
+    projectId: string;
+    challenge: {a: number; b: number; answer: number};
+    safetyRecord: BackupRecord | null;
+    initialized: boolean;
+  }>({
+    record: null,
+    composePath: '',
+    storage: null,
+    projectId: '',
+    challenge: generateChallenge(),
+    safetyRecord: null,
+    initialized: false,
+  });
+
+  // One-shot init: resolve the backup, then branch
+  if (!ref.current.initialized) {
+    ref.current.initialized = true;
+    (async () => {
+      const pc = readProjectConfig();
+      if (!pc) {
+        setErrorMsg('This project is not initialized. Run "kiqr init" first.');
+        setPhase('error');
+        setTimeout(() => exit(new Error()), 100);
+        return;
+      }
+      const composePath = path.join(getProjectRuntimeDir(pc.project_id), 'compose.yaml');
+      const storage = createBackupStorage(getProjectBackupsDir(pc.project_id));
+      ref.current.composePath = composePath;
+      ref.current.storage = storage;
+      ref.current.projectId = pc.project_id;
+
+      const record = await storage.findById(args[0]);
+      if (!record) {
+        setErrorMsg(`No backup with id "${args[0]}". Run "kiqr db list" to see available backups.`);
+        setPhase('error');
+        setTimeout(() => exit(new Error()), 100);
+        return;
+      }
+      ref.current.record = record;
+
+      const recent = await storage.mostRecent();
+      const hasRecent = recent && Date.now() - recent.createdAt.getTime() < FIVE_MINUTES_MS;
+      if (!hasRecent) {
+        setPhase('ask-safety-backup');
+      } else {
+        if (isWordPressInstalled(composePath)) {
+          setPhase('ask-captcha');
+        } else {
+          setPhase('running-restore');
+        }
+      }
+    })().catch((err) => {
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+      setPhase('error');
+      setTimeout(() => exit(new Error()), 100);
+    });
+  }
+
+  if (phase === 'loading') return <Text dimColor>Loading...</Text>;
+
+  if (phase === 'error') return <Text color="red">{errorMsg}</Text>;
+
+  if (phase === 'ask-safety-backup') {
+    return (
+      <Box flexDirection="column" paddingTop={1}>
+        <Text>No backup has been made in the last 5 minutes.</Text>
+        <Box marginTop={1}>
+          <Text>Make a safety backup first? </Text>
+          <ConfirmInput
+            onConfirm={() => setPhase('running-safety-backup')}
+            onCancel={() => {
+              if (isWordPressInstalled(ref.current.composePath)) {
+                setPhase('ask-captcha');
+              } else {
+                setPhase('running-restore');
+              }
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (phase === 'ask-captcha') {
+    const challenge = ref.current.challenge;
+    return (
+      <Box flexDirection="column" paddingTop={1}>
+        <Text color="yellow" bold>
+          This will overwrite the current database with backup {ref.current.record!.id}.
+        </Text>
+        <Text> </Text>
+        <Text>To confirm, solve this: <Text bold color="yellow">What is {challenge.a} + {challenge.b}?</Text></Text>
+        <Box marginTop={1}>
+          {wrong && <Text color="red">Wrong answer. </Text>}
+          <Text dimColor>Answer: </Text>
+          <TextInput
+            onSubmit={(value) => {
+              if (parseInt(value, 10) === challenge.answer) {
+                setPhase('running-restore');
+              } else {
+                setWrong(true);
+                ref.current.challenge = generateChallenge();
+                setTimeout(() => exit(new Error()), 100);
+              }
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (phase === 'running-safety-backup') {
+    const steps: Step[] = [
+      {
+        label: 'Creating safety backup...',
+        run: async () => {
+          try {
+            ref.current.safetyRecord = await runDump(
+              ref.current.composePath,
+              ref.current.storage!,
+              ref.current.projectId,
+            );
+          } catch (err) {
+            throw new Error(
+              `Safety backup failed; restore aborted. ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        },
+      },
+    ];
+    return (
+      <Box flexDirection="column">
+        <StepRunner
+          steps={steps}
+          onComplete={() => {
+            if (isWordPressInstalled(ref.current.composePath)) {
+              setPhase('ask-captcha');
+            } else {
+              setPhase('running-restore');
+            }
+          }}
+          onError={() => setTimeout(() => exit(new Error()), 100)}
+        />
+      </Box>
+    );
+  }
+
+  if (phase === 'running-restore') {
+    const steps: Step[] = [
+      {
+        label: `Restoring database from ${ref.current.record!.id}...`,
+        run: async () => {
+          await runRestore(ref.current.composePath, ref.current.record!, ref.current.storage!);
+        },
+      },
+    ];
+    return (
+      <Box flexDirection="column">
+        <StepRunner
+          steps={steps}
+          onComplete={() => {
+            setPhase('done');
+            setTimeout(() => exit(), 100);
+          }}
+          onError={() => setTimeout(() => exit(new Error()), 100)}
+        />
+      </Box>
+    );
+  }
+
+  // phase === 'done'
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold color="green">Database restored from {ref.current.record!.id}.</Text>
+      {ref.current.safetyRecord && (
+        <Text dimColor>Safety backup saved as {ref.current.safetyRecord.id}.</Text>
+      )}
+    </Box>
+  );
+}

--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -16,6 +16,7 @@ export default function Index() {
       <Text>  <Text bold>kiqr info</Text>      Show project info and credentials</Text>
       <Text>  <Text bold>kiqr open</Text>      Open site, admin, or phpMyAdmin in browser</Text>
       <Text>  <Text bold>kiqr wp</Text>        Run a WP-CLI command</Text>
+      <Text>  <Text bold>kiqr db</Text>        Backup and restore the database</Text>
       <Text>  <Text bold>kiqr logs</Text>      Show WordPress logs</Text>
       <Text>  <Text bold>kiqr destroy</Text>   Remove all site data and start fresh</Text>
       <Text> </Text>

--- a/src/lib/backup-storage.ts
+++ b/src/lib/backup-storage.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {pipeline} from 'node:stream/promises';
+import type {Readable} from 'node:stream';
+import {
+  BACKUP_EXTENSION,
+  SIDECAR_EXTENSION,
+  buildBackupFilename,
+  parseBackupFilename,
+} from './backups.js';
+
+export interface BackupRecord {
+  id: string;
+  filename: string;
+  path: string;
+  sidecarPath: string;
+  projectId: string;
+  host: string;
+  createdAt: Date;
+  sizeBytes: number;
+  sha256: string;
+}
+
+export interface SaveOptions {
+  projectId: string;
+  host: string;
+  createdAt: Date;
+  id: string;
+}
+
+export interface BackupStorage {
+  list(): Promise<BackupRecord[]>;
+  findById(id: string): Promise<BackupRecord | null>;
+  mostRecent(): Promise<BackupRecord | null>;
+  save(stream: Readable, opts: SaveOptions): Promise<BackupRecord>;
+  openRead(record: BackupRecord): Readable;
+  delete(record: BackupRecord): Promise<void>;
+}
+
+interface SidecarJson {
+  id: string;
+  projectId: string;
+  host: string;
+  createdAt: string;
+  sizeBytes: number;
+  sha256: string;
+  filename: string;
+}
+
+export class LocalBackupStorage implements BackupStorage {
+  private readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+  }
+
+  private sidecarPathFor(backupPath: string): string {
+    return backupPath.slice(0, -BACKUP_EXTENSION.length) + SIDECAR_EXTENSION;
+  }
+
+  async list(): Promise<BackupRecord[]> {
+    if (!fs.existsSync(this.dir)) return [];
+    const entries = await fs.promises.readdir(this.dir);
+    const records: BackupRecord[] = [];
+    for (const name of entries) {
+      if (!name.endsWith(BACKUP_EXTENSION)) continue;
+      const parts = parseBackupFilename(name);
+      if (!parts) continue;
+      const backupPath = path.join(this.dir, name);
+      const sidecarPath = this.sidecarPathFor(backupPath);
+      if (!fs.existsSync(sidecarPath)) continue;
+      const sidecar = JSON.parse(await fs.promises.readFile(sidecarPath, 'utf-8')) as SidecarJson;
+      records.push({
+        id: sidecar.id,
+        filename: name,
+        path: backupPath,
+        sidecarPath,
+        projectId: sidecar.projectId,
+        host: sidecar.host,
+        createdAt: new Date(sidecar.createdAt),
+        sizeBytes: sidecar.sizeBytes,
+        sha256: sidecar.sha256,
+      });
+    }
+    records.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return records;
+  }
+
+  async findById(id: string): Promise<BackupRecord | null> {
+    const all = await this.list();
+    return all.find((r) => r.id === id) ?? null;
+  }
+
+  async mostRecent(): Promise<BackupRecord | null> {
+    const all = await this.list();
+    return all[0] ?? null;
+  }
+
+  async save(stream: Readable, opts: SaveOptions): Promise<BackupRecord> {
+    fs.mkdirSync(this.dir, {recursive: true});
+    const filename = buildBackupFilename({host: opts.host, date: opts.createdAt, id: opts.id});
+    const backupPath = path.join(this.dir, filename);
+    const sidecarPath = this.sidecarPathFor(backupPath);
+
+    const hash = crypto.createHash('sha256');
+    let sizeBytes = 0;
+    const out = fs.createWriteStream(backupPath);
+    stream.on('data', (chunk: Buffer) => {
+      hash.update(chunk);
+      sizeBytes += chunk.length;
+    });
+    await pipeline(stream, out);
+
+    const sidecar: SidecarJson = {
+      id: opts.id,
+      projectId: opts.projectId,
+      host: opts.host,
+      createdAt: opts.createdAt.toISOString(),
+      sizeBytes,
+      sha256: hash.digest('hex'),
+      filename,
+    };
+    await fs.promises.writeFile(sidecarPath, JSON.stringify(sidecar, null, 2), 'utf-8');
+
+    return {
+      id: opts.id,
+      filename,
+      path: backupPath,
+      sidecarPath,
+      projectId: opts.projectId,
+      host: opts.host,
+      createdAt: opts.createdAt,
+      sizeBytes,
+      sha256: sidecar.sha256,
+    };
+  }
+
+  openRead(record: BackupRecord): Readable {
+    return fs.createReadStream(record.path);
+  }
+
+  async delete(record: BackupRecord): Promise<void> {
+    await fs.promises.rm(record.path, {force: true});
+    await fs.promises.rm(record.sidecarPath, {force: true});
+  }
+}
+
+export class RemoteBackupStorage implements BackupStorage {
+  private err(method: string): Error {
+    return new Error(
+      `RemoteBackupStorage.${method} is not implemented yet. ` +
+        'Cloud sync will land with the Kiqr Cloud release.',
+    );
+  }
+  async list(): Promise<BackupRecord[]> {
+    throw this.err('list');
+  }
+  async findById(_id: string): Promise<BackupRecord | null> {
+    throw this.err('findById');
+  }
+  async mostRecent(): Promise<BackupRecord | null> {
+    throw this.err('mostRecent');
+  }
+  async save(_stream: Readable, _opts: SaveOptions): Promise<BackupRecord> {
+    throw this.err('save');
+  }
+  openRead(_record: BackupRecord): Readable {
+    throw this.err('openRead');
+  }
+  async delete(_record: BackupRecord): Promise<void> {
+    throw this.err('delete');
+  }
+}
+
+export function createBackupStorage(runtimeBackupsDir: string): BackupStorage {
+  return new LocalBackupStorage(runtimeBackupsDir);
+}

--- a/src/lib/backups.ts
+++ b/src/lib/backups.ts
@@ -1,0 +1,54 @@
+export const BACKUP_EXTENSION = '.sql.gz';
+export const SIDECAR_EXTENSION = '.json';
+
+const FILENAME_RE =
+  /^(?<host>[a-z0-9-]+)-(?<date>\d{8})-(?<time>\d{6})-(?<id>[0-9a-z]+)\.sql\.gz$/;
+
+export interface BackupFilenameParts {
+  host: string;
+  date: Date;
+  id: string;
+}
+
+export function encodeBackupId(date: Date, rng: () => number = Math.random): string {
+  const seconds = Math.floor(date.getTime() / 1000);
+  const prefix = seconds.toString(36);
+  const suffix = Math.floor(rng() * 36 * 36)
+    .toString(36)
+    .padStart(2, '0');
+  return `${prefix}${suffix}`;
+}
+
+export function decodeBackupTimestamp(id: string): Date {
+  const prefix = id.slice(0, -2);
+  const seconds = parseInt(prefix, 36);
+  return new Date(seconds * 1000);
+}
+
+function pad(n: number, width: number): string {
+  return n.toString().padStart(width, '0');
+}
+
+export function buildBackupFilename(parts: BackupFilenameParts): string {
+  const d = parts.date;
+  const ymd = `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1, 2)}${pad(d.getUTCDate(), 2)}`;
+  const hms = `${pad(d.getUTCHours(), 2)}${pad(d.getUTCMinutes(), 2)}${pad(d.getUTCSeconds(), 2)}`;
+  return `${parts.host}-${ymd}-${hms}-${parts.id}${BACKUP_EXTENSION}`;
+}
+
+export function parseBackupFilename(filename: string): BackupFilenameParts | null {
+  const m = FILENAME_RE.exec(filename);
+  if (!m?.groups) return null;
+  const {host, date, time, id} = m.groups;
+  const year = parseInt(date!.slice(0, 4), 10);
+  const month = parseInt(date!.slice(4, 6), 10) - 1;
+  const day = parseInt(date!.slice(6, 8), 10);
+  const hour = parseInt(time!.slice(0, 2), 10);
+  const minute = parseInt(time!.slice(2, 4), 10);
+  const second = parseInt(time!.slice(4, 6), 10);
+  return {
+    host: host!,
+    date: new Date(Date.UTC(year, month, day, hour, minute, second)),
+    id: id!,
+  };
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -40,3 +40,7 @@ export function getProjectPluginsDir(projectId: string, platform: NodeJS.Platfor
 export function getProjectUploadsDir(projectId: string, platform: NodeJS.Platform = process.platform): string {
   return path.join(getProjectRuntimeDir(projectId, platform), 'uploads');
 }
+
+export function getProjectBackupsDir(projectId: string, platform: NodeJS.Platform = process.platform): string {
+  return path.join(getProjectRuntimeDir(projectId, platform), 'backups');
+}

--- a/src/lib/wpcli.ts
+++ b/src/lib/wpcli.ts
@@ -1,0 +1,21 @@
+import {spawn, spawnSync, type ChildProcessByStdio} from 'node:child_process';
+import type {Readable, Writable} from 'node:stream';
+
+export function buildWpCliArgs(composePath: string, wpArgs: string[]): string[] {
+  return ['compose', '-f', composePath, 'run', '--rm', '-T', 'wpcli', ...wpArgs];
+}
+
+export type WpCliProcess = ChildProcessByStdio<Writable, Readable, Readable>;
+
+export function spawnWpCli(composePath: string, wpArgs: string[]): WpCliProcess {
+  return spawn('docker', buildWpCliArgs(composePath, wpArgs), {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) as WpCliProcess;
+}
+
+export function isWordPressInstalled(composePath: string): boolean {
+  const result = spawnSync('docker', buildWpCliArgs(composePath, ['wp', 'core', 'is-installed']), {
+    stdio: 'pipe',
+  });
+  return result.status === 0;
+}

--- a/tests/lib/backup-storage.test.ts
+++ b/tests/lib/backup-storage.test.ts
@@ -1,0 +1,100 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {Readable} from 'node:stream';
+import {createGzip} from 'node:zlib';
+import {
+  LocalBackupStorage,
+  RemoteBackupStorage,
+  createBackupStorage,
+} from '../../src/lib/backup-storage.js';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kiqr-backups-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, {recursive: true, force: true});
+});
+
+describe('LocalBackupStorage.save', () => {
+  it('stores a gzipped stream and writes a sidecar', async () => {
+    const storage = new LocalBackupStorage(tmp);
+    const src = Readable.from(['SELECT 1;\n']).pipe(createGzip());
+    const date = new Date('2026-06-05T14:30:12.000Z');
+    const record = await storage.save(src, {
+      projectId: 'proj-1',
+      host: 'my-mbp',
+      createdAt: date,
+      id: 'abc12xy',
+    });
+    expect(record.filename).toBe('my-mbp-20260605-143012-abc12xy.sql.gz');
+    expect(fs.existsSync(record.path)).toBe(true);
+    expect(fs.existsSync(record.path.replace('.sql.gz', '.json'))).toBe(true);
+    const sidecar = JSON.parse(fs.readFileSync(record.path.replace('.sql.gz', '.json'), 'utf-8'));
+    expect(sidecar.id).toBe('abc12xy');
+    expect(sidecar.projectId).toBe('proj-1');
+    expect(sidecar.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(sidecar.sizeBytes).toBeGreaterThan(0);
+  });
+});
+
+describe('LocalBackupStorage.list / findById', () => {
+  it('lists all valid backups newest-first and finds by id', async () => {
+    const storage = new LocalBackupStorage(tmp);
+    for (const id of ['aaa11ax', 'bbb22by']) {
+      const src = Readable.from([`SELECT '${id}';`]).pipe(createGzip());
+      const offsetMs = id.startsWith('aaa') ? 0 : 60_000;
+      await storage.save(src, {
+        projectId: 'p',
+        host: 'h',
+        createdAt: new Date(Date.parse('2026-06-05T14:30:12Z') + offsetMs),
+        id,
+      });
+    }
+    const list = await storage.list();
+    expect(list.map((r) => r.id)).toEqual(['bbb22by', 'aaa11ax']);
+    const found = await storage.findById('aaa11ax');
+    expect(found?.filename).toContain('aaa11ax');
+  });
+
+  it('returns an empty list when the dir does not exist', async () => {
+    const storage = new LocalBackupStorage(path.join(tmp, 'missing'));
+    expect(await storage.list()).toEqual([]);
+    expect(await storage.findById('whatever')).toBeNull();
+  });
+});
+
+describe('LocalBackupStorage.mostRecent', () => {
+  it('returns the newest record or null', async () => {
+    const storage = new LocalBackupStorage(tmp);
+    expect(await storage.mostRecent()).toBeNull();
+    const src = Readable.from(['a']).pipe(createGzip());
+    await storage.save(src, {
+      projectId: 'p',
+      host: 'h',
+      createdAt: new Date(),
+      id: 'newest1',
+    });
+    const rec = await storage.mostRecent();
+    expect(rec?.id).toBe('newest1');
+  });
+});
+
+describe('RemoteBackupStorage', () => {
+  it('throws not-implemented on all methods', async () => {
+    const remote = new RemoteBackupStorage();
+    await expect(remote.list()).rejects.toThrow(/not implemented/i);
+    await expect(remote.findById('x')).rejects.toThrow(/not implemented/i);
+    await expect(remote.mostRecent()).rejects.toThrow(/not implemented/i);
+  });
+});
+
+describe('createBackupStorage', () => {
+  it('returns a LocalBackupStorage by default', () => {
+    const s = createBackupStorage(tmp);
+    expect(s).toBeInstanceOf(LocalBackupStorage);
+  });
+});

--- a/tests/lib/backups.test.ts
+++ b/tests/lib/backups.test.ts
@@ -1,0 +1,54 @@
+import {describe, it, expect} from 'vitest';
+import {
+  encodeBackupId,
+  decodeBackupTimestamp,
+  buildBackupFilename,
+  parseBackupFilename,
+  BACKUP_EXTENSION,
+  SIDECAR_EXTENSION,
+} from '../../src/lib/backups.js';
+
+describe('encodeBackupId', () => {
+  it('produces a stable base36 prefix from a Date and a 2-char random suffix', () => {
+    const date = new Date('2026-06-05T14:30:12.000Z');
+    const id = encodeBackupId(date, () => 0.5);
+    const expectedPrefix = Math.floor(date.getTime() / 1000).toString(36);
+    expect(id.startsWith(expectedPrefix)).toBe(true);
+    expect(id).toMatch(/^[0-9a-z]{8,}$/);
+    expect(id.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe('decodeBackupTimestamp', () => {
+  it('round-trips with encodeBackupId', () => {
+    const date = new Date('2026-06-05T14:30:12.000Z');
+    const id = encodeBackupId(date, () => 0.1);
+    expect(decodeBackupTimestamp(id).getTime()).toBe(date.getTime());
+  });
+});
+
+describe('buildBackupFilename / parseBackupFilename', () => {
+  it('builds and parses round-trip', () => {
+    const filename = buildBackupFilename({
+      host: 'my-mbp',
+      date: new Date('2026-06-05T14:30:12.000Z'),
+      id: 'abc12xy',
+    });
+    expect(filename).toBe(`my-mbp-20260605-143012-abc12xy${BACKUP_EXTENSION}`);
+    const parsed = parseBackupFilename(filename);
+    expect(parsed).toEqual({
+      host: 'my-mbp',
+      date: new Date('2026-06-05T14:30:12.000Z'),
+      id: 'abc12xy',
+    });
+  });
+
+  it('parseBackupFilename returns null on non-matching names', () => {
+    expect(parseBackupFilename('not-a-backup.txt')).toBeNull();
+    expect(parseBackupFilename('only-prefix.sql.gz')).toBeNull();
+  });
+
+  it('exports the sidecar extension', () => {
+    expect(SIDECAR_EXTENSION).toBe('.json');
+  });
+});

--- a/tests/lib/paths.test.ts
+++ b/tests/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {getKiqrDataDir, getProjectRuntimeDir} from '../../src/lib/paths.js';
+import {getKiqrDataDir, getProjectRuntimeDir, getProjectBackupsDir} from '../../src/lib/paths.js';
 
 describe('getKiqrDataDir', () => {
   beforeEach(() => {
@@ -34,5 +34,21 @@ describe('getProjectRuntimeDir', () => {
     vi.stubEnv('HOME', '/Users/testuser');
     const result = getProjectRuntimeDir('abc-123', 'darwin');
     expect(result).toBe('/Users/testuser/Library/Application Support/Kiqr/projects/abc-123');
+  });
+});
+
+describe('getProjectBackupsDir', () => {
+  it('returns <runtimeDir>/backups on darwin', () => {
+    vi.stubEnv('HOME', '/Users/test');
+    expect(getProjectBackupsDir('abc-123', 'darwin')).toBe(
+      '/Users/test/Library/Application Support/Kiqr/projects/abc-123/backups',
+    );
+  });
+
+  it('returns <runtimeDir>/backups on linux', () => {
+    vi.stubEnv('HOME', '/home/test');
+    expect(getProjectBackupsDir('abc-123', 'linux')).toBe(
+      '/home/test/.config/kiqr/projects/abc-123/backups',
+    );
   });
 });

--- a/tests/lib/wpcli.test.ts
+++ b/tests/lib/wpcli.test.ts
@@ -1,0 +1,21 @@
+import {describe, it, expect} from 'vitest';
+import {buildWpCliArgs} from '../../src/lib/wpcli.js';
+
+describe('buildWpCliArgs', () => {
+  it('produces a docker compose run invocation with -T to disable TTY', () => {
+    const args = buildWpCliArgs('/path/compose.yaml', ['wp', 'db', 'export', '-']);
+    expect(args).toEqual([
+      'compose',
+      '-f',
+      '/path/compose.yaml',
+      'run',
+      '--rm',
+      '-T',
+      'wpcli',
+      'wp',
+      'db',
+      'export',
+      '-',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- New command group `kiqr db` with three subcommands:
  - `kiqr db dump` — streams `wp db export -` through gzip into `<runtimeDir>/backups/`, with a per-backup `.json` sidecar (id, projectId, host, createdAt, sizeBytes, sha256).
  - `kiqr db list` — table view: `id | filename | size | date`, newest first.
  - `kiqr db restore <id>` — multi-stage flow:
    1. If no backup is younger than 5 minutes, offer a safety dump first. A failed safety dump aborts restore (DB untouched).
    2. If WordPress is installed (`wp core is-installed` exit 0), gate restore behind a `kiqr destroy`-style math captcha.
    3. Otherwise restore directly.
- Backup IDs are base36-encoded unix-seconds + 2 random chars and are embedded in the filename so lookup is a readdir scan — two-way: timestamp ↔ id ↔ file.
- Storage is fronted by a `BackupStorage` interface (`src/lib/backup-storage.ts`). `LocalBackupStorage` is the only shipped implementation; a `RemoteBackupStorage` stub class documents the seam for the future Kiqr Cloud sync (all methods throw \"not implemented\").
- Backups live alongside `uploads/` and `plugins/` under each project's runtime dir (new `getProjectBackupsDir` helper in `src/lib/paths.ts`).
- No changes to `BitnamiRuntimeProvider` — dumps stream over stdin/stdout between host and the ephemeral `wpcli` container (`docker compose run --rm -T wpcli ...`), so no new volume mount is needed.

## Why

There was no way to snapshot the project DB. Devs lost work to \`kiqr destroy\`, bad migrations, or plugin experiments, and there was no clean way to share state with a teammate. This adds first-class backup/restore using WP-CLI under the hood, and stages the storage layer for cloud sync without shipping any cloud code.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 55/55 passing across 12 files (new units: `tests/lib/backups.test.ts`, `tests/lib/backup-storage.test.ts`, `tests/lib/wpcli.test.ts`, plus an addition to `tests/lib/paths.test.ts`)
- [x] `npm run build` — produces `dist/commands/db/{index,dump,list,restore}.js`
- [ ] **Manual, needs Docker + a real theme repo:**
  - [ ] \`kiqr db dump\` → backup file + sidecar appear under \`<dataDir>/projects/<uuid>/backups/\`; success screen shows ID and filename
  - [ ] \`kiqr db list\` → table renders, newest first
  - [ ] Restore — **empty DB** path: \`kiqr destroy\` → \`kiqr up\` → \`kiqr db restore <id>\` with N to safety prompt → restores without captcha
  - [ ] Restore — **non-empty DB** path: with content present → captcha required
  - [ ] Restore — **safety-backup-first** path: > 5 min since last backup → Y at prompt → new dump appears in list, then restore proceeds; success message references both ids
  - [ ] Restore — **safety-backup failure** path: stop mariadb mid-safety-dump → restore aborts, DB untouched
  - [ ] \`new RemoteBackupStorage().list()\` throws \"not implemented\"

## Notes for reviewer

- Plan lives at \`docs/superpowers/plans/2026-05-29-kiqr-cli-mvp.md\` is unrelated; this work followed an in-session plan saved to \`~/.claude/plans/\`. Happy to copy it into \`docs/superpowers/plans/\` if you'd like that as part of the PR.
- One deliberate deviation from the original plan: TS 6's \`erasableSyntaxOnly\` (enabled via \`@sindresorhus/tsconfig\`) forbids parameter-property syntax, so \`LocalBackupStorage\` uses an explicit field + constructor assignment instead of \`constructor(private readonly dir: string)\`. Behaviour-identical.
- Initial \`wp db export --stdout\` invocation didn't work (\`--stdout\` was passed through to \`mariadb-dump\`, which rejected it). Corrected to \`wp db export -\` (the \`-\` filename means stdout in wp-cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)