### PR TITLE
fix: remove unused symbols breaking typecheck in watch command

### DIFF
--- a/src/commands/watch.tsx
+++ b/src/commands/watch.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect, useRef} from 'react';
-import {Box, Text, useApp} from 'ink';
+import {Box, Text} from 'ink';
 import {readProjectConfig} from '../lib/config.js';
 import {detectTheme} from '../lib/theme.js';
 import {createFileWatcher, getRelativePath} from '../lib/watch.js';
@@ -14,12 +14,11 @@ interface FileChange {
 }
 
 export default function Watch() {
-  const {exit} = useApp();
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [changes, setChanges] = useState<FileChange[]>([]);
   const [connected, setConnected] = useState(0);
-  const [lrPort, setLrPort] = useState(35729);
+  const [lrPort] = useState(35729);
 
   const watcherRef = useRef<{stop: () => void} | null>(null);
   const liveReloadRef = useRef<LiveReloadServer | null>(null);


### PR DESCRIPTION
## Problem

`npm run typecheck` (`tsc --noEmit`) fails with two `TS6133` errors in `src/commands/watch.tsx`:

```
src/commands/watch.tsx(17,9): error TS6133: 'exit' is declared but its value is never read.
src/commands/watch.tsx(22,18): error TS6133: 'setLrPort' is declared but its value is never read.
```

Because `make publish` runs `typecheck` before `build`, this currently **blocks publishing** the package. (`tsup`/esbuild doesn't enforce strict `tsc`, so the build alone stays green and the issue is easy to miss.)

## Fix

- Remove the unused `exit` destructure from `useApp()` and drop the now-unused `useApp` import.
- Remove the unused `setLrPort` setter — `lrPort` is only read.

No behavior change.

## Verification

- `npm run typecheck` → passes
- `npm test` → 66 passed (14 files)
- `npm run build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)