### PR TITLE
ci: add GitHub Actions workflow (typecheck, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-progress runs for the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/src/commands/watch.tsx
+++ b/src/commands/watch.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect, useRef} from 'react';
-import {Box, Text, useApp} from 'ink';
+import {Box, Text} from 'ink';
 import {readProjectConfig} from '../lib/config.js';
 import {detectTheme} from '../lib/theme.js';
 import {createFileWatcher, getRelativePath} from '../lib/watch.js';
@@ -14,12 +14,11 @@ interface FileChange {
 }
 
 export default function Watch() {
-  const {exit} = useApp();
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [changes, setChanges] = useState<FileChange[]>([]);
   const [connected, setConnected] = useState(0);
-  const [lrPort, setLrPort] = useState(35729);
+  const [lrPort] = useState(35729);
 
   const watcherRef = useRef<{stop: () => void} | null>(null);
   const liveReloadRef = useRef<LiveReloadServer | null>(null);


### PR DESCRIPTION
## What

Adds the project's first CI pipeline (`.github/workflows/ci.yml`). Runs on every push to `main` and on all pull requests, across **Node 20 / 22 / 24**:

- `npm ci`
- `npm run typecheck`
- `npm test` (66 tests)
- `npm run build`

Plus concurrency cancellation so rapid pushes don't pile up CI runs.

## Why

There is currently no automated gate. A published npm package (`@kiqr/cli`) can ship a regression that only the developer running `npm test` locally would catch. This makes `main` self-verifying and protects every future PR.

## ⚠️ Depends on #6

This branch is stacked on #6. `main` currently fails `tsc --noEmit` (two unused-symbol errors fixed in #6), so **#6 should merge first** for CI to be green. Once #6 is merged, the only change here is the workflow file.

## Verification

Ran the exact pipeline locally on Node 24 — all green:
- typecheck ✅
- test → 66 passed (14 files) ✅
- build ✅

Note: GitHub may require a maintainer to approve the first workflow run on a PR from a fork.