### PR TITLE
fix: surface docker compose errors instead of swallowing them

### DIFF
--- a/src/commands/watch.tsx
+++ b/src/commands/watch.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect, useRef} from 'react';
-import {Box, Text, useApp} from 'ink';
+import {Box, Text} from 'ink';
 import {readProjectConfig} from '../lib/config.js';
 import {detectTheme} from '../lib/theme.js';
 import {createFileWatcher, getRelativePath} from '../lib/watch.js';
@@ -14,12 +14,11 @@ interface FileChange {
 }
 
 export default function Watch() {
-  const {exit} = useApp();
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [changes, setChanges] = useState<FileChange[]>([]);
   const [connected, setConnected] = useState(0);
-  const [lrPort, setLrPort] = useState(35729);
+  const [lrPort] = useState(35729);
 
   const watcherRef = useRef<{stop: () => void} | null>(null);
   const liveReloadRef = useRef<LiveReloadServer | null>(null);

--- a/src/lib/docker.ts
+++ b/src/lib/docker.ts
@@ -23,9 +23,26 @@ export function runDockerCompose(
   command: string,
   args: string[] = [],
 ): void {
-  execSync(`docker compose -f "${composeFile}" ${command} ${args.join(' ')}`, {
-    stdio: 'pipe',
-  });
+  try {
+    execSync(`docker compose -f "${composeFile}" ${command} ${args.join(' ')}`, {
+      stdio: 'pipe',
+    });
+  } catch (error) {
+    // execSync captures the subprocess output on the thrown error when
+    // stdio is piped. Surface it so failures (port conflicts, image pull
+    // errors, etc.) are diagnosable instead of silently swallowed.
+    const err = error as {
+      stderr?: Buffer | string;
+      stdout?: Buffer | string;
+      message?: string;
+    };
+    const detail =
+      err.stderr?.toString().trim() ||
+      err.stdout?.toString().trim() ||
+      err.message ||
+      'unknown error';
+    throw new Error(`docker compose ${command} failed:\n${detail}`);
+  }
 }
 
 export function removeDockerVolume(name: string): void {

--- a/tests/lib/docker.test.ts
+++ b/tests/lib/docker.test.ts
@@ -1,5 +1,9 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {isDockerInstalled, isDockerRunning} from '../../src/lib/docker.js';
+import {
+  isDockerInstalled,
+  isDockerRunning,
+  runDockerCompose,
+} from '../../src/lib/docker.js';
 import {execSync} from 'node:child_process';
 
 vi.mock('node:child_process', () => ({
@@ -41,5 +45,48 @@ describe('isDockerRunning', () => {
       throw new Error('Cannot connect');
     });
     expect(isDockerRunning()).toBe(false);
+  });
+});
+
+describe('runDockerCompose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not throw when the command succeeds', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from(''));
+    expect(() => runDockerCompose('/tmp/compose.yaml', 'up', ['-d'])).not.toThrow();
+  });
+
+  it('surfaces the captured stderr in the thrown error', () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Command failed'), {
+        stderr: Buffer.from('Error: port 5477 is already allocated'),
+      });
+    });
+    expect(() => runDockerCompose('/tmp/compose.yaml', 'up', ['-d'])).toThrow(
+      /port 5477 is already allocated/,
+    );
+  });
+
+  it('falls back to stdout when stderr is empty', () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Command failed'), {
+        stderr: Buffer.from(''),
+        stdout: Buffer.from('pull access denied for some-image'),
+      });
+    });
+    expect(() => runDockerCompose('/tmp/compose.yaml', 'up')).toThrow(
+      /pull access denied/,
+    );
+  });
+
+  it('falls back to the error message when no output is captured', () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error('spawn docker ENOENT');
+    });
+    expect(() => runDockerCompose('/tmp/compose.yaml', 'down')).toThrow(
+      /spawn docker ENOENT/,
+    );
   });
 });


### PR DESCRIPTION
## Problem

`runDockerCompose()` (src/lib/docker.ts) runs with `stdio: 'pipe'` and no error handling. When `docker compose up`/`down`/`restart`/`destroy` fails — port already allocated, image pull failure, daemon not reachable — the subprocess output is discarded and the thrown error carries no detail. The user sees a red step ("Starting WordPress and database…") with **no reason why**. This is the single biggest UX papercut in the tool.

## Fix

Wrap the `execSync` call and rethrow with the captured output: `stderr` first, falling back to `stdout`, then the error message. The throw-on-failure contract is unchanged — callers already catch and render thrown errors via `StepRunner`'s `onError`, so failures now show the actual Docker message.

```
docker compose up failed:
Error response from daemon: ... port 5477 is already allocated
```

## Tests

Adds 4 tests to `tests/lib/docker.test.ts`: success path, stderr surfacing, stdout fallback, and message fallback. Full suite: **70 passed** (was 66).

## Notes

Stacked on #6 so CI is green (main currently fails typecheck — see #6). Independent of #7. Verified locally: typecheck ✅, 70 tests ✅, build ✅.