### PR TITLE
chore: pin infrastructure docker image versions

### DIFF
--- a/src/commands/watch.tsx
+++ b/src/commands/watch.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect, useRef} from 'react';
-import {Box, Text, useApp} from 'ink';
+import {Box, Text} from 'ink';
 import {readProjectConfig} from '../lib/config.js';
 import {detectTheme} from '../lib/theme.js';
 import {createFileWatcher, getRelativePath} from '../lib/watch.js';
@@ -14,12 +14,11 @@ interface FileChange {
 }
 
 export default function Watch() {
-  const {exit} = useApp();
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [changes, setChanges] = useState<FileChange[]>([]);
   const [connected, setConnected] = useState(0);
-  const [lrPort, setLrPort] = useState(35729);
+  const [lrPort] = useState(35729);
 
   const watcherRef = useRef<{stop: () => void} | null>(null);
   const liveReloadRef = useRef<LiveReloadServer | null>(null);

--- a/src/lib/traefik.ts
+++ b/src/lib/traefik.ts
@@ -29,7 +29,7 @@ export function generateTraefikCompose(traefikDir: string): string {
         restart: 'unless-stopped',
       },
       splash: {
-        image: 'nginx:alpine',
+        image: 'nginx:1.30-alpine',
         container_name: 'kiqr-splash',
         volumes: [
           `${path.join(traefikDir, 'splash.html')}:/usr/share/nginx/html/splash.html:ro`,

--- a/src/providers/BitnamiRuntimeProvider.ts
+++ b/src/providers/BitnamiRuntimeProvider.ts
@@ -65,7 +65,7 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         restart: 'unless-stopped',
       },
       mariadb: {
-        image: 'mariadb:latest',
+        image: 'mariadb:11.4',
         environment: {
           MARIADB_ROOT_PASSWORD: config.dbPassword,
           MARIADB_USER: credentials.dbUser,
@@ -77,7 +77,7 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         restart: 'unless-stopped',
       },
       wpcli: {
-        image: 'wordpress:cli',
+        image: 'wordpress:cli-php8.3',
         environment: {
           WORDPRESS_DB_HOST: 'mariadb',
           WORDPRESS_DB_NAME: credentials.dbName,
@@ -96,7 +96,7 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         user: '33:33',
       },
       phpmyadmin: {
-        image: 'phpmyadmin:latest',
+        image: 'phpmyadmin:5.2',
         environment: {
           PMA_HOST: 'mariadb',
           PMA_USER: 'root',

--- a/tests/lib/traefik.test.ts
+++ b/tests/lib/traefik.test.ts
@@ -34,7 +34,7 @@ describe('generateTraefikCompose', () => {
     const yaml = generateTraefikCompose('/tmp/kiqr/traefik');
     const parsed = YAML.parse(yaml);
     expect(parsed.services.splash).toBeDefined();
-    expect(parsed.services.splash.image).toBe('nginx:alpine');
+    expect(parsed.services.splash.image).toBe('nginx:1.30-alpine');
     const labels = parsed.services.splash.labels;
     expect(labels.some((l: string) => l.includes('priority=1'))).toBe(true);
   });

--- a/tests/providers/BitnamiRuntimeProvider.test.ts
+++ b/tests/providers/BitnamiRuntimeProvider.test.ts
@@ -43,7 +43,7 @@ describe('BitnamiRuntimeProvider', () => {
     expect(services['mariadb']).toBeDefined();
     expect(services['phpmyadmin']).toBeDefined();
     expect(services['wordpress']!.image).toBe('wordpress:6.7');
-    expect(services['mariadb']!.image).toBe('mariadb:latest');
+    expect(services['mariadb']!.image).toBe('mariadb:11.4');
   });
 
   it('uses latest when version is latest', () => {


### PR DESCRIPTION
## Problem

The supporting service images float on mutable tags: `mariadb:latest`, `phpmyadmin:latest`, `wordpress:cli`, `nginx:alpine`. An upstream major release (e.g. MariaDB bumping major, or a breaking phpMyAdmin/nginx change) can break existing projects on a routine `kiqr restart` with **no change on the user's side** — the classic 'it worked yesterday' failure.

## Fix

Pin the images KIQR controls to known-good tags. Every tag below was verified to exist on Docker Hub before pinning:

| Service | Before | After |
|---|---|---|
| mariadb | `mariadb:latest` | `mariadb:11.4` (LTS) |
| phpmyadmin | `phpmyadmin:latest` | `phpmyadmin:5.2` |
| wpcli | `wordpress:cli` | `wordpress:cli-php8.3` (matches the WP image's php8.3 default) |
| splash (nginx) | `nginx:alpine` | `nginx:1.30-alpine` (stable) |

**Left unchanged:** the user-selectable WordPress image (`wordpress.version` in `kiqr.yaml`) and the already-pinned `traefik:v2.11`.

## Tests

Updated the two assertions that referenced the old tags (`BitnamiRuntimeProvider.test.ts`, `traefik.test.ts`). Full suite: 66 passed.

## Notes

Stacked on #6 for green CI. Independent of #7/#8. Verified locally: typecheck ✅, tests ✅, build ✅.