### PR TITLE
feat: validate kiqr.yaml and config.yaml with zod schemas

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,23 +1,84 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
-import type {ProjectConfig, LocalConfig} from '../types/config.js';
+import {z} from 'zod';
+import type {LocalConfig, ProjectConfig} from '../types/config.js';
 
 const PROJECT_CONFIG_FILE = 'kiqr.yaml';
 const LOCAL_CONFIG_FILE = 'config.yaml';
+
+const projectConfigSchema = z.object({
+  project_id: z.string().min(1, 'project_id is required'),
+  name: z.string().min(1, 'name is required'),
+  wordpress: z.object({
+    version: z.string().min(1, 'wordpress.version is required'),
+    php_version: z.string().min(1, 'wordpress.php_version is required'),
+  }),
+  development: z.object({
+    dynamic_urls: z.boolean(),
+  }),
+}) satisfies z.ZodType<ProjectConfig>;
+
+const localConfigSchema = z.object({
+  project_id: z.string().min(1, 'project_id is required'),
+  runtime: z.string().min(1, 'runtime is required'),
+  db_password: z.string().min(1, 'db_password is required'),
+  login_secret: z.string().min(1, 'login_secret is required'),
+  wordpress_version: z.string().optional(),
+  created_at: z.string().min(1, 'created_at is required'),
+}) satisfies z.ZodType<LocalConfig>;
+
+/**
+ * Turn a Zod validation error into a single, human-readable line so a
+ * hand-edited config file produces an actionable message instead of a
+ * cryptic downstream crash.
+ */
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const pathStr = issue.path.join('.');
+      return pathStr ? `${pathStr}: ${issue.message}` : issue.message;
+    })
+    .join(', ');
+}
+
+function parseConfig<T>(
+  schema: z.ZodType<T>,
+  content: string,
+  fileName: string,
+): T {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(content);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${fileName} is not valid YAML: ${detail}`);
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`${fileName} is invalid: ${formatIssues(result.error)}`);
+  }
+  return result.data;
+}
 
 export function projectConfigExists(dir: string = process.cwd()): boolean {
   return fs.existsSync(path.join(dir, PROJECT_CONFIG_FILE));
 }
 
-export function readProjectConfig(dir: string = process.cwd()): ProjectConfig | null {
+export function readProjectConfig(
+  dir: string = process.cwd(),
+): ProjectConfig | null {
   const filePath = path.join(dir, PROJECT_CONFIG_FILE);
   if (!fs.existsSync(filePath)) return null;
   const content = fs.readFileSync(filePath, 'utf-8');
-  return YAML.parse(content) as ProjectConfig;
+  return parseConfig(projectConfigSchema, content, PROJECT_CONFIG_FILE);
 }
 
-export function writeProjectConfig(config: ProjectConfig, dir: string = process.cwd()): void {
+export function writeProjectConfig(
+  config: ProjectConfig,
+  dir: string = process.cwd(),
+): void {
   const filePath = path.join(dir, PROJECT_CONFIG_FILE);
   fs.writeFileSync(filePath, YAML.stringify(config), 'utf-8');
 }
@@ -26,7 +87,7 @@ export function readLocalConfig(dir: string): LocalConfig | null {
   const filePath = path.join(dir, LOCAL_CONFIG_FILE);
   if (!fs.existsSync(filePath)) return null;
   const content = fs.readFileSync(filePath, 'utf-8');
-  return YAML.parse(content) as LocalConfig;
+  return parseConfig(localConfigSchema, content, LOCAL_CONFIG_FILE);
 }
 
 export function writeLocalConfig(config: LocalConfig, dir: string): void {

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -40,6 +40,34 @@ describe('project config', () => {
   it('returns null when kiqr.yaml does not exist', () => {
     expect(readProjectConfig(tmpDir)).toBeNull();
   });
+
+  it('throws a clear error when a required field is missing', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'kiqr.yaml'),
+      'project_id: abc\nwordpress:\n  version: latest\n  php_version: "8.3"\ndevelopment:\n  dynamic_urls: true\n',
+      'utf-8',
+    );
+    expect(() => readProjectConfig(tmpDir)).toThrow(/kiqr\.yaml is invalid/);
+    expect(() => readProjectConfig(tmpDir)).toThrow(/name/);
+  });
+
+  it('throws a clear error when a field has the wrong type', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'kiqr.yaml'),
+      'project_id: abc\nname: my-theme\nwordpress:\n  version: latest\n  php_version: "8.3"\ndevelopment:\n  dynamic_urls: "yes"\n',
+      'utf-8',
+    );
+    expect(() => readProjectConfig(tmpDir)).toThrow(/development\.dynamic_urls/);
+  });
+
+  it('throws a clear error when the YAML is malformed', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'kiqr.yaml'),
+      'name: my-theme\n  : : broken\n\t bad indent',
+      'utf-8',
+    );
+    expect(() => readProjectConfig(tmpDir)).toThrow(/kiqr\.yaml is not valid YAML/);
+  });
 });
 
 describe('local config', () => {
@@ -66,5 +94,19 @@ describe('local config', () => {
 
     const loaded = readLocalConfig(tmpDir);
     expect(loaded).toEqual(config);
+  });
+
+  it('returns null when config.yaml does not exist', () => {
+    expect(readLocalConfig(tmpDir)).toBeNull();
+  });
+
+  it('throws a clear error when a required field is missing', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.yaml'),
+      'project_id: test-uuid\nruntime: bitnami\n',
+      'utf-8',
+    );
+    expect(() => readLocalConfig(tmpDir)).toThrow(/config\.yaml is invalid/);
+    expect(() => readLocalConfig(tmpDir)).toThrow(/db_password/);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the unsafe `YAML.parse(content) as ProjectConfig` / `as LocalConfig` casts in `src/lib/config.ts` with [zod](https://zod.dev/) schema parsing (`zod` is already a dependency).

A malformed or hand-edited `kiqr.yaml` / `config.yaml` now fails fast with a clear, actionable message instead of crashing somewhere downstream:

- Validation failure: `kiqr.yaml is invalid: name: ...` (file + field named)
- Bad YAML syntax: `config.yaml is not valid YAML: <detail>`

## Details

- Schemas are defined alongside the readers and constrained to the existing interfaces in `src/types/config.ts` via `satisfies z.ZodType<ProjectConfig>` / `<LocalConfig>`. This keeps the public TS types and every import of them unchanged, and the `satisfies` check guarantees the schemas stay in sync with the types at compile time.
- A small helper flattens zod issues into a single readable line.

## Tests

Adds coverage in `tests/lib/config.test.ts`:
- valid config parses (existing tests still pass)
- missing required field throws a clear, file+field-scoped error
- wrong field type throws
- malformed YAML throws the "not valid YAML" error
- both `kiqr.yaml` and `config.yaml`

`npm run typecheck`, `npm test` (75 passing), and `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)