### PR TITLE
feat: add kiqr doctor preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Theme Name: My Theme
 | `kiqr down` | Stop the development environment |
 | `kiqr restart` | Restart the development environment |
 | `kiqr init` | Initialize a new project |
+| `kiqr doctor` | Check your environment for common problems |
 | `kiqr info` | Show project info and credentials |
 | `kiqr open` | Open the site in your browser |
 | `kiqr open admin` | Open the WordPress dashboard (auto-login) |

--- a/src/commands/doctor.tsx
+++ b/src/commands/doctor.tsx
@@ -1,0 +1,49 @@
+import {Box, Text, useApp} from 'ink';
+import {useEffect, useState} from 'react';
+import {type DoctorCheck, runDoctorChecks} from '../lib/doctor.js';
+
+export const description = 'Check your environment for common problems';
+
+export default function Doctor() {
+  const {exit} = useApp();
+  const [checks, setChecks] = useState<DoctorCheck[] | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const results = await runDoctorChecks();
+      setChecks(results);
+      const ok = results.every((c) => c.ok);
+      setTimeout(() => exit(ok ? undefined : new Error()), 100);
+    })();
+  }, []);
+
+  if (!checks) return <Text dimColor>Running checks...</Text>;
+
+  const allOk = checks.every((c) => c.ok);
+
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      {checks.map((check) => (
+        <Box key={check.name}>
+          <Text color={check.ok ? 'green' : 'red'}>
+            {check.ok ? '✓' : '✗'}{' '}
+          </Text>
+          <Text>{check.name}</Text>
+          <Text dimColor> — {check.detail}</Text>
+        </Box>
+      ))}
+      <Box marginTop={1}>
+        {allOk ? (
+          <Text bold color="green">
+            Everything looks good.
+          </Text>
+        ) : (
+          <Text bold color="red">
+            Some checks failed. Resolve the issues above and run "kiqr doctor"
+            again.
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -9,6 +9,7 @@ export default function Index() {
       <Text dimColor>Local WordPress theme development</Text>
       <Text> </Text>
       <Text>Commands:</Text>
+      <Text>  <Text bold>kiqr doctor</Text>    Check your environment for common problems</Text>
       <Text>  <Text bold>kiqr init</Text>      Initialize a new project</Text>
       <Text>  <Text bold>kiqr up</Text>        Start the development environment</Text>
       <Text>  <Text bold>kiqr down</Text>      Stop the development environment</Text>

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import {isDockerInstalled, isDockerRunning} from './docker.js';
+import {isPortAvailable} from './ports.js';
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** Traefik web entrypoint (see src/lib/traefik.ts). */
+export const TRAEFIK_PORT = 5477;
+/** LiveReload SSE server (see src/lib/livereload.ts). */
+export const LIVERELOAD_PORT = 35729;
+
+/**
+ * Returns true when running under the Windows Subsystem for Linux.
+ * WSL kernels include "microsoft" in /proc/version.
+ */
+export function isWSL(): boolean {
+  try {
+    const version = fs.readFileSync('/proc/version', 'utf-8').toLowerCase();
+    return version.includes('microsoft') || version.includes('wsl');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Runs cheap, read-only environment preflight checks and reports the
+ * result of each. Pure aside from reading the environment (Docker CLI,
+ * /proc/version, local sockets) — does not start or mutate anything.
+ */
+export async function runDoctorChecks(): Promise<DoctorCheck[]> {
+  const checks: DoctorCheck[] = [];
+
+  const dockerInstalled = isDockerInstalled();
+  checks.push({
+    name: 'Docker installed',
+    ok: dockerInstalled,
+    detail: dockerInstalled
+      ? 'docker CLI found'
+      : 'docker CLI not found — install Docker Desktop or the Docker engine',
+  });
+
+  // Only probe the daemon if the CLI exists; `docker info` is meaningless
+  // (and slow to fail) without it.
+  if (dockerInstalled) {
+    const dockerRunning = isDockerRunning();
+    checks.push({
+      name: 'Docker running',
+      ok: dockerRunning,
+      detail: dockerRunning
+        ? 'docker daemon is responding'
+        : 'docker daemon is not responding — start Docker and try again',
+    });
+  } else {
+    checks.push({
+      name: 'Docker running',
+      ok: false,
+      detail: 'skipped — Docker is not installed',
+    });
+  }
+
+  const traefikFree = await isPortAvailable(TRAEFIK_PORT);
+  checks.push({
+    name: `Traefik port ${TRAEFIK_PORT} available`,
+    ok: traefikFree,
+    detail: traefikFree
+      ? 'port is free'
+      : `port ${TRAEFIK_PORT} is in use — stop the process using it before "kiqr up"`,
+  });
+
+  const livereloadFree = await isPortAvailable(LIVERELOAD_PORT);
+  checks.push({
+    name: `LiveReload port ${LIVERELOAD_PORT} available`,
+    ok: livereloadFree,
+    detail: livereloadFree
+      ? 'port is free'
+      : `port ${LIVERELOAD_PORT} is in use — "kiqr watch" reload may not work`,
+  });
+
+  const wsl = isWSL();
+  checks.push({
+    name: 'Platform',
+    ok: true,
+    detail: wsl ? 'WSL detected — use the Docker Desktop WSL integration' : 'native',
+  });
+
+  return checks;
+}

--- a/tests/lib/doctor.test.ts
+++ b/tests/lib/doctor.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {isDockerInstalled, isDockerRunning} from '../../src/lib/docker.js';
+import {
+  isWSL,
+  LIVERELOAD_PORT,
+  runDoctorChecks,
+  TRAEFIK_PORT,
+} from '../../src/lib/doctor.js';
+import {isPortAvailable} from '../../src/lib/ports.js';
+
+vi.mock('../../src/lib/docker.js', () => ({
+  isDockerInstalled: vi.fn(),
+  isDockerRunning: vi.fn(),
+}));
+
+vi.mock('../../src/lib/ports.js', () => ({
+  isPortAvailable: vi.fn(),
+}));
+
+const mockInstalled = vi.mocked(isDockerInstalled);
+const mockRunning = vi.mocked(isDockerRunning);
+const mockPort = vi.mocked(isPortAvailable);
+
+function find(checks: Awaited<ReturnType<typeof runDoctorChecks>>, name: string) {
+  const check = checks.find((c) => c.name === name);
+  if (!check) throw new Error(`check not found: ${name}`);
+  return check;
+}
+
+describe('runDoctorChecks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Healthy defaults; individual tests override.
+    mockInstalled.mockReturnValue(true);
+    mockRunning.mockReturnValue(true);
+    mockPort.mockResolvedValue(true);
+  });
+
+  it('reports all green when the environment is healthy', async () => {
+    const checks = await runDoctorChecks();
+    expect(find(checks, 'Docker installed').ok).toBe(true);
+    expect(find(checks, 'Docker running').ok).toBe(true);
+    expect(find(checks, `Traefik port ${TRAEFIK_PORT} available`).ok).toBe(true);
+    expect(find(checks, `LiveReload port ${LIVERELOAD_PORT} available`).ok).toBe(
+      true,
+    );
+  });
+
+  it('fails the Docker installed check when the CLI is missing', async () => {
+    mockInstalled.mockReturnValue(false);
+    const checks = await runDoctorChecks();
+    expect(find(checks, 'Docker installed').ok).toBe(false);
+    expect(find(checks, 'Docker installed').detail).toMatch(/not found/);
+  });
+
+  it('does not probe the daemon when Docker is not installed', async () => {
+    mockInstalled.mockReturnValue(false);
+    const checks = await runDoctorChecks();
+    expect(mockRunning).not.toHaveBeenCalled();
+    expect(find(checks, 'Docker running').ok).toBe(false);
+    expect(find(checks, 'Docker running').detail).toMatch(/skipped/);
+  });
+
+  it('fails the Docker running check when the daemon is down', async () => {
+    mockRunning.mockReturnValue(false);
+    const checks = await runDoctorChecks();
+    expect(find(checks, 'Docker running').ok).toBe(false);
+    expect(find(checks, 'Docker running').detail).toMatch(/not responding/);
+  });
+
+  it('checks the Traefik and LiveReload ports', async () => {
+    await runDoctorChecks();
+    expect(mockPort).toHaveBeenCalledWith(TRAEFIK_PORT);
+    expect(mockPort).toHaveBeenCalledWith(LIVERELOAD_PORT);
+  });
+
+  it('fails the port check when a port is in use', async () => {
+    mockPort.mockImplementation(async (port: number) => port !== TRAEFIK_PORT);
+    const checks = await runDoctorChecks();
+    expect(find(checks, `Traefik port ${TRAEFIK_PORT} available`).ok).toBe(false);
+    expect(find(checks, `LiveReload port ${LIVERELOAD_PORT} available`).ok).toBe(
+      true,
+    );
+  });
+
+  it('always reports the platform check as informational (ok)', async () => {
+    const checks = await runDoctorChecks();
+    expect(find(checks, 'Platform').ok).toBe(true);
+  });
+});
+
+describe('isWSL', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when /proc/version mentions microsoft', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      'Linux version 5.15.0-microsoft-standard-WSL2',
+    );
+    expect(isWSL()).toBe(true);
+  });
+
+  it('returns false for a native kernel', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      'Linux version 6.0.0-generic',
+    );
+    expect(isWSL()).toBe(false);
+  });
+
+  it('returns false when /proc/version cannot be read', () => {
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(isWSL()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `kiqr doctor` command that runs cheap, read-only environment preflight checks and reports each as pass/fail with an actionable message. Useful before `kiqr up` to catch the usual culprits.

Checks:
- **Docker installed** (`isDockerInstalled`)
- **Docker running** (`isDockerRunning`) — skipped cleanly when the CLI isn't present
- **Traefik port 5477 available** (`isPortAvailable`)
- **LiveReload port 35729 available** (`isPortAvailable`)
- **Platform** — detects WSL via `/proc/version` (informational)

## Design

- All check logic is in a pure, testable `src/lib/doctor.ts` that returns `{name, ok, detail}[]`.
- `src/commands/doctor.tsx` is a thin Ink renderer that exits non-zero if any check fails.
- The port constants reference the values already used by `src/lib/traefik.ts` and `src/lib/livereload.ts`, and this gives the previously-unused `isPortAvailable` helper a real caller.

## Tests

`tests/lib/doctor.test.ts` (10 cases) mocks the docker/ports modules and `node:fs` (for WSL detection), following the existing `tests/lib/docker.test.ts` / `tests/lib/ports.test.ts` style. Covers healthy env, missing Docker CLI (and that the daemon is then not probed), daemon down, both port checks, port-in-use, and WSL detection.

Also lists `kiqr doctor` in the `kiqr` help screen and the README command table.

`npm run typecheck`, `npm test` (80 passing), and `npm run build` all green.

> Note: this command only performs static/read-only checks (no `docker compose run`), so it is fully verifiable without a Docker daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)