### PR TITLE
feat: apply configured php_version to the WordPress image

### DIFF
--- a/src/commands/restart.tsx
+++ b/src/commands/restart.tsx
@@ -108,6 +108,7 @@ export default function Restart() {
             hostname,
             phpMyAdminHostname,
             wordpressVersion: pc.wordpress.version,
+            phpVersion: pc.wordpress.php_version,
             dbPassword: lc.db_password,
             loginSecret: lc.login_secret,
             muPluginPath,

--- a/src/commands/up.tsx
+++ b/src/commands/up.tsx
@@ -163,6 +163,7 @@ export default function Up() {
             hostname,
             phpMyAdminHostname,
             wordpressVersion: pc.wordpress.version,
+            phpVersion: pc.wordpress.php_version,
             dbPassword: lc.db_password,
             loginSecret: lc.login_secret,
             muPluginPath,

--- a/src/providers/BitnamiRuntimeProvider.ts
+++ b/src/providers/BitnamiRuntimeProvider.ts
@@ -8,9 +8,13 @@ import type {
 const KIQR_NETWORK = 'kiqr';
 
 export class BitnamiRuntimeProvider implements RuntimeProvider {
-  getWordPressImage(version: string, _phpVersion: string): string {
-    if (version === 'latest') return 'wordpress:latest';
-    return `wordpress:${version}`;
+  getWordPressImage(version: string, phpVersion: string): string {
+    // The official `wordpress` image publishes PHP-pinned tags:
+    //   - `wordpress:php8.3` for the latest WordPress on a given PHP version
+    //   - `wordpress:6.7-php8.3` for a specific WordPress + PHP combination
+    // See https://hub.docker.com/_/wordpress/tags
+    if (version === 'latest') return `wordpress:php${phpVersion}`;
+    return `wordpress:${version}-php${phpVersion}`;
   }
 
   getThemeMountTarget(themeSlug: string): string {
@@ -39,7 +43,7 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
 
     return {
       wordpress: {
-        image: this.getWordPressImage(config.wordpressVersion, '8.3'),
+        image: this.getWordPressImage(config.wordpressVersion, config.phpVersion),
         environment: {
           ...this.getEnvironmentVariables(credentials),
           KIQR_LOGIN_SECRET: config.loginSecret,
@@ -77,7 +81,7 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         restart: 'unless-stopped',
       },
       wpcli: {
-        image: 'wordpress:cli-php8.3',
+        image: `wordpress:cli-php${config.phpVersion}`,
         environment: {
           WORDPRESS_DB_HOST: 'mariadb',
           WORDPRESS_DB_NAME: credentials.dbName,

--- a/src/providers/RuntimeProvider.ts
+++ b/src/providers/RuntimeProvider.ts
@@ -18,6 +18,7 @@ export interface RuntimeConfig {
   hostname: string;
   phpMyAdminHostname: string;
   wordpressVersion: string;
+  phpVersion: string;
   dbPassword: string;
   loginSecret: string;
   muPluginPath: string;

--- a/tests/lib/compose.test.ts
+++ b/tests/lib/compose.test.ts
@@ -11,6 +11,7 @@ describe('generateProjectCompose', () => {
     hostname: 'my-theme.test.local',
     phpMyAdminHostname: 'phpmyadmin.my-theme.test.local',
     wordpressVersion: 'latest',
+    phpVersion: '8.3',
     dbPassword: 'test_password',
     loginSecret: 'secret123',
     muPluginPath: '/tmp/mu-plugin.php',

--- a/tests/providers/BitnamiRuntimeProvider.test.ts
+++ b/tests/providers/BitnamiRuntimeProvider.test.ts
@@ -4,9 +4,19 @@ import {BitnamiRuntimeProvider} from '../../src/providers/BitnamiRuntimeProvider
 describe('BitnamiRuntimeProvider', () => {
   const provider = new BitnamiRuntimeProvider();
 
-  it('returns wordpress image name', () => {
+  it('returns the php-pinned latest image when version is latest', () => {
     const image = provider.getWordPressImage('latest', '8.3');
-    expect(image).toBe('wordpress:latest');
+    expect(image).toBe('wordpress:php8.3');
+  });
+
+  it('returns a version+php-pinned image for a specific version', () => {
+    const image = provider.getWordPressImage('6.7', '8.4');
+    expect(image).toBe('wordpress:6.7-php8.4');
+  });
+
+  it('honors the configured php version', () => {
+    expect(provider.getWordPressImage('latest', '8.2')).toBe('wordpress:php8.2');
+    expect(provider.getWordPressImage('6.7', '8.2')).toBe('wordpress:6.7-php8.2');
   });
 
   it('returns correct theme mount target', () => {
@@ -32,6 +42,7 @@ describe('BitnamiRuntimeProvider', () => {
       hostname: 'my-theme.test.lvh.me',
       phpMyAdminHostname: 'phpmyadmin.my-theme.test.lvh.me',
       wordpressVersion: '6.7',
+      phpVersion: '8.3',
       dbPassword: 'test_password',
       loginSecret: 'secret123',
       muPluginPath: '/tmp/mu-plugin.php',
@@ -42,7 +53,8 @@ describe('BitnamiRuntimeProvider', () => {
     expect(services['wordpress']).toBeDefined();
     expect(services['mariadb']).toBeDefined();
     expect(services['phpmyadmin']).toBeDefined();
-    expect(services['wordpress']!.image).toBe('wordpress:6.7');
+    expect(services['wordpress']!.image).toBe('wordpress:6.7-php8.3');
+    expect(services['wpcli']!.image).toBe('wordpress:cli-php8.3');
     expect(services['mariadb']!.image).toBe('mariadb:11.4');
   });
 
@@ -54,6 +66,7 @@ describe('BitnamiRuntimeProvider', () => {
       hostname: 'my-theme.test.lvh.me',
       phpMyAdminHostname: 'phpmyadmin.my-theme.test.lvh.me',
       wordpressVersion: 'latest',
+      phpVersion: '8.4',
       dbPassword: 'test_password',
       loginSecret: 'secret123',
       muPluginPath: '/tmp/mu-plugin.php',
@@ -61,6 +74,7 @@ describe('BitnamiRuntimeProvider', () => {
       uploadsPath: '/tmp/uploads',
       dataDir: '/tmp/kiqr/projects/uuid',
     });
-    expect(services['wordpress']!.image).toBe('wordpress:latest');
+    expect(services['wordpress']!.image).toBe('wordpress:php8.4');
+    expect(services['wpcli']!.image).toBe('wordpress:cli-php8.4');
   });
 });


### PR DESCRIPTION
## Summary

`WordPressConfig.php_version` was written to `kiqr.yaml` by `kiqr init` but never read — `BitnamiRuntimeProvider.getWordPressImage()` hardcoded PHP 8.3. This wires the configured `php_version` through `RuntimeConfig` so the config key actually selects the image.

Image tag mapping:

| WordPress version | Image |
|---|---|
| `latest` | `wordpress:php<php_version>` (e.g. `wordpress:php8.3`) |
| pinned `<ver>` | `wordpress:<ver>-php<php_version>` (e.g. `wordpress:6.7-php8.3`) |
| wp-cli service | `wordpress:cli-php<php_version>` (kept in sync with the runtime PHP) |

## Tag verification

Before relying on these schemes I verified the tags exist on Docker Hub via the registry API:
- bare `php8.2`, `php8.3`, `php8.4`, `php8.5` ✅
- `6.7-php8.3` (and the general `<ver>-php<ver>` scheme) ✅
- `cli-php8.2` … `cli-php8.5` ✅

## Safety

- The default `php_version` is `'8.3'`, so the default image becomes `wordpress:php8.3`, which is functionally equivalent to the previous `wordpress:latest` — no surprise upgrade for existing users.
- This is a **pure image-tag string change**; it does not change how `docker compose` / `docker compose run` are invoked.

## Tests

`tests/providers/BitnamiRuntimeProvider.test.ts` updated to cover both the `latest` and pinned-version paths plus the wp-cli image; `phpVersion` added to the `RuntimeConfig` fixtures in the provider and compose tests.

`npm run typecheck`, `npm test` (72 passing), and `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)