### PR TITLE
fix: use chokidar for reliable cross-platform file watching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@kiqr/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiqr/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
+        "chokidar": "^5.0.0",
         "ink": "^7.0.5",
         "pastel": "^4.0.1",
         "react": "^19.2.6",
@@ -1625,16 +1626,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2850,13 +2850,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -3321,6 +3320,36 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
+    "chokidar": "^5.0.0",
     "ink": "^7.0.5",
     "pastel": "^4.0.1",
     "react": "^19.2.6",

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
 import path from 'node:path';
+import chokidar from 'chokidar';
 
 export interface WatchOptions {
   extensions?: string[];
@@ -47,13 +47,13 @@ export function createFileWatcher(
   }
 
   function handleFileChange(
-    eventType: 'rename' | 'change',
+    event: 'add' | 'change' | 'unlink',
     filePath: string,
   ) {
     if (isIgnored(filePath)) return;
     if (!matchesExtensions(filePath)) return;
 
-    const key = `${eventType}:${filePath}`;
+    const key = `${event}:${filePath}`;
     const existingTimer = debounceTimers.get(key);
 
     if (existingTimer) {
@@ -62,31 +62,21 @@ export function createFileWatcher(
 
     const timer = setTimeout(() => {
       debounceTimers.delete(key);
-
-      if (eventType === 'rename') {
-        try {
-          if (fs.existsSync(filePath)) {
-            callback('add', filePath);
-          } else {
-            callback('unlink', filePath);
-          }
-        } catch {
-          callback('unlink', filePath);
-        }
-      } else {
-        callback('change', filePath);
-      }
+      callback(event, filePath);
     }, debounceDelay);
 
     debounceTimers.set(key, timer);
   }
 
-  const watcher = fs.watch(watchDir, {recursive: true}, (eventType, filename) => {
-    if (!filename) return;
-
-    const fullPath = path.join(watchDir, filename);
-    handleFileChange(eventType as 'rename' | 'change', fullPath);
+  const watcher = chokidar.watch(watchDir, {
+    ignoreInitial: true,
+    ignored: (filePath) => isIgnored(filePath),
+    persistent: true,
   });
+
+  watcher.on('add', (filePath) => handleFileChange('add', filePath));
+  watcher.on('change', (filePath) => handleFileChange('change', filePath));
+  watcher.on('unlink', (filePath) => handleFileChange('unlink', filePath));
 
   return {
     stop: () => {
@@ -94,7 +84,7 @@ export function createFileWatcher(
         clearTimeout(timer);
       }
       debounceTimers.clear();
-      watcher.close();
+      void watcher.close();
     },
   };
 }

--- a/tests/lib/watch.test.ts
+++ b/tests/lib/watch.test.ts
@@ -33,13 +33,15 @@ describe('watch', () => {
   });
 
   describe('createFileWatcher', () => {
-    it('reports file changes', () => new Promise((resolve) => {
+    it('reports file changes', () => new Promise<void>((resolve) => {
       const callback = vi.fn();
       const watcher = createFileWatcher(tempDir, {extensions: ['.php']}, callback);
 
-      // Create a test file
-      const testFile = path.join(tempDir, 'test.php');
-      fs.writeFileSync(testFile, '<?php // test');
+      // Give chokidar time to begin watching before writing.
+      setTimeout(() => {
+        const testFile = path.join(tempDir, 'test.php');
+        fs.writeFileSync(testFile, '<?php // test');
+      }, 200);
 
       // Give it time to detect the change
       setTimeout(() => {
@@ -47,42 +49,64 @@ describe('watch', () => {
         // At least one callback should have been called (add or change)
         expect(callback.mock.calls.length).toBeGreaterThan(0);
         resolve();
-      }, 200);
-    }));
+      }, 800);
+    }), 5000);
 
-    it('ignores files without matching extensions', () => new Promise((resolve) => {
+    it('detects changes in nested subdirectories', () => new Promise<void>((resolve) => {
       const callback = vi.fn();
       const watcher = createFileWatcher(tempDir, {extensions: ['.php']}, callback);
 
-      // Create a non-matching file
-      const testFile = path.join(tempDir, 'test.txt');
-      fs.writeFileSync(testFile, 'test content');
+      setTimeout(() => {
+        const nestedDir = path.join(tempDir, 'src', 'components', 'deep');
+        fs.mkdirSync(nestedDir, {recursive: true});
+        fs.writeFileSync(path.join(nestedDir, 'Header.php'), '<?php // nested');
+      }, 200);
+
+      setTimeout(() => {
+        watcher.stop();
+        const matched = callback.mock.calls.some(
+          ([, filePath]) => typeof filePath === 'string' && filePath.endsWith('Header.php'),
+        );
+        expect(matched).toBe(true);
+        resolve();
+      }, 800);
+    }), 5000);
+
+    it('ignores files without matching extensions', () => new Promise<void>((resolve) => {
+      const callback = vi.fn();
+      const watcher = createFileWatcher(tempDir, {extensions: ['.php']}, callback);
+
+      setTimeout(() => {
+        const testFile = path.join(tempDir, 'test.txt');
+        fs.writeFileSync(testFile, 'test content');
+      }, 200);
 
       setTimeout(() => {
         watcher.stop();
         // No callbacks should have been called for .txt files
         expect(callback).not.toHaveBeenCalled();
         resolve();
-      }, 200);
-    }));
+      }, 800);
+    }), 5000);
 
-    it('ignores node_modules directories', () => new Promise((resolve) => {
+    it('ignores node_modules directories', () => new Promise<void>((resolve) => {
       const callback = vi.fn();
       const watcher = createFileWatcher(tempDir, {extensions: ['.php']}, callback);
 
-      // Create a file in node_modules
-      const nodeModulesDir = path.join(tempDir, 'node_modules');
-      fs.mkdirSync(nodeModulesDir, {recursive: true});
-      const testFile = path.join(nodeModulesDir, 'test.php');
-      fs.writeFileSync(testFile, '<?php // test');
+      setTimeout(() => {
+        // Create a file in node_modules
+        const nodeModulesDir = path.join(tempDir, 'node_modules');
+        fs.mkdirSync(nodeModulesDir, {recursive: true});
+        fs.writeFileSync(path.join(nodeModulesDir, 'test.php'), '<?php // test');
+      }, 200);
 
       setTimeout(() => {
         watcher.stop();
         // No callbacks for node_modules
         expect(callback).not.toHaveBeenCalled();
         resolve();
-      }, 200);
-    }));
+      }, 800);
+    }), 5000);
 
     it('returns a stop function', () => {
       const callback = vi.fn();


### PR DESCRIPTION
## Summary

Replaces Node's `fs.watch({recursive: true})` with [chokidar](https://github.com/paulmillr/chokidar) in `src/lib/watch.ts` for reliable cross-platform file watching.

## Why

`fs.watch`'s `recursive` option is not reliably supported across platforms. On some Linux kernels recursive watching of nested directories is unsupported or flaky, so file changes in subdirectories (e.g. `src/components/Header.php`) could be silently missed during `kiqr watch`. chokidar handles recursive watching consistently across macOS, Linux, and Windows.

## What changed

- `createFileWatcher` now uses `chokidar.watch`, listening to its native `add` / `change` / `unlink` events — which map directly onto the existing `FileChangeCallback`.
- **Public API is unchanged**: same signature, same returned `{stop}` shape, same options (extension filtering, debounce, ignore patterns). `src/commands/watch.tsx` needs no changes.
- `getRelativePath` is untouched.
- Ignore patterns are applied via chokidar's `ignored` predicate (so it won't even descend into `node_modules`, `.git`, etc.) while preserving the existing regex/string-array `ignored` option.

## Tests

`tests/lib/watch.test.ts` updated to run against real temp-dir filesystem events with chokidar timing, and a new test verifies detection of files created in nested subdirectories.

- `npm run typecheck` ✅
- `npm test` ✅ (71 tests, 14 files)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)