### PR TITLE
test: add unit tests for mu-plugin, splash, and nginx-splash

### DIFF
--- a/tests/lib/mu-plugin.test.ts
+++ b/tests/lib/mu-plugin.test.ts
@@ -1,0 +1,93 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {writeMuPlugin} from '../../src/lib/mu-plugin.js';
+
+describe('writeMuPlugin', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kiqr-mu-plugin-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, {recursive: true, force: true});
+  });
+
+  it('writes the mu-plugin file and returns its path', () => {
+    const filePath = writeMuPlugin(tmp);
+    expect(filePath).toBe(path.join(tmp, 'kiqr-auto-login.php'));
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('creates the runtime directory if it does not exist', () => {
+    const nested = path.join(tmp, 'a', 'b', 'c');
+    const filePath = writeMuPlugin(nested);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('writes a guarded WordPress PHP plugin header', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content.startsWith('<?php')).toBe(true);
+    expect(content).toContain('Plugin Name: Kiqr Development');
+    // Bails out unless development mode is explicitly enabled
+    expect(content).toContain("!defined('KIQR_DEVELOPMENT')");
+    expect(content).toContain('!KIQR_DEVELOPMENT');
+  });
+
+  it('auto-activates the mounted theme by slug on init', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("add_action('init'");
+    expect(content).toContain("getenv('KIQR_THEME_SLUG')");
+    expect(content).toContain('switch_theme($slug)');
+    // Only activates once, then records that it did so
+    expect(content).toContain("get_option('kiqr_theme_activated')");
+    expect(content).toContain("update_option('kiqr_theme_activated', '1')");
+    expect(content).toContain('$theme->exists()');
+  });
+
+  it('implements signed-URL auto-login with constant-time secret comparison', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("$_GET['kiqr_login']");
+    expect(content).toContain('is_user_logged_in()');
+    expect(content).toContain("getenv('KIQR_LOGIN_SECRET')");
+    // hash_equals guards against timing attacks
+    expect(content).toContain("hash_equals($secret, $_GET['kiqr_login'])");
+    expect(content).toContain('wp_set_current_user($user->ID)');
+    expect(content).toContain('wp_set_auth_cookie($user->ID, true)');
+  });
+
+  it('falls back to the first administrator when no admin login exists', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("get_user_by('login', 'admin')");
+    expect(content).toContain("get_users(['role' => 'administrator', 'number' => 1])");
+  });
+
+  it('redirects and exits after a successful auto-login', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("remove_query_arg('kiqr_login')");
+    expect(content).toContain('wp_safe_redirect($redirect ?: admin_url())');
+    expect(content).toContain('exit;');
+  });
+
+  it('injects a LiveReload script tag into the footer with the configured port', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("add_action('wp_footer'");
+    expect(content).toContain("getenv('KIQR_LIVERELOAD_PORT')");
+    expect(content).toContain('<script src="http://localhost:');
+    expect(content).toContain("'/livereload.js?ver='");
+    expect(content).toContain('esc_attr($lr_port)');
+  });
+
+  it('defaults the LiveReload port to 35729 when unset', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("if (!$lr_port) $lr_port = '35729'");
+  });
+
+  it('is deterministic across writes', () => {
+    const first = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    const second = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(first).toBe(second);
+  });
+});

--- a/tests/lib/nginx-splash.test.ts
+++ b/tests/lib/nginx-splash.test.ts
@@ -1,0 +1,49 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {writeNginxSplashConf} from '../../src/lib/nginx-splash.js';
+
+describe('writeNginxSplashConf', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kiqr-nginx-splash-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, {recursive: true, force: true});
+  });
+
+  it('writes splash-nginx.conf and returns its path', () => {
+    const filePath = writeNginxSplashConf(tmp);
+    expect(filePath).toBe(path.join(tmp, 'splash-nginx.conf'));
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('creates the target directory if it does not exist', () => {
+    const nested = path.join(tmp, 'traefik', 'dynamic');
+    const filePath = writeNginxSplashConf(nested);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('defines a catch-all server listening on port 80', () => {
+    const content = fs.readFileSync(writeNginxSplashConf(tmp), 'utf-8');
+    expect(content).toContain('server {');
+    expect(content).toContain('listen 80;');
+    expect(content).toContain('server_name _;');
+  });
+
+  it('serves the splash page from the nginx html root', () => {
+    const content = fs.readFileSync(writeNginxSplashConf(tmp), 'utf-8');
+    expect(content).toContain('location / {');
+    expect(content).toContain('root /usr/share/nginx/html;');
+    expect(content).toContain('try_files /splash.html =404;');
+  });
+
+  it('is deterministic across writes', () => {
+    const first = fs.readFileSync(writeNginxSplashConf(tmp), 'utf-8');
+    const second = fs.readFileSync(writeNginxSplashConf(tmp), 'utf-8');
+    expect(first).toBe(second);
+  });
+});

--- a/tests/lib/splash.test.ts
+++ b/tests/lib/splash.test.ts
@@ -1,0 +1,66 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {writeSplashPage} from '../../src/lib/splash.js';
+
+describe('writeSplashPage', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kiqr-splash-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, {recursive: true, force: true});
+  });
+
+  it('writes splash.html and returns its path', () => {
+    const filePath = writeSplashPage(tmp);
+    expect(filePath).toBe(path.join(tmp, 'splash.html'));
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('creates the target directory if it does not exist', () => {
+    const nested = path.join(tmp, 'traefik', 'dynamic');
+    const filePath = writeSplashPage(nested);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('produces a well-formed HTML document', () => {
+    const content = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(content.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(content).toContain('<html lang="en">');
+    expect(content.trimEnd().endsWith('</html>')).toBe(true);
+    expect(content).toContain('<title>Kiqr</title>');
+  });
+
+  it('shows the no-site-running message and brand marker', () => {
+    const content = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(content).toContain('No site is running at this address');
+    expect(content).toContain('<div class="logo">Kiqr</div>');
+  });
+
+  it('instructs the user how to start a site and view help', () => {
+    const content = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(content).toContain('<code>kiqr up</code>');
+    expect(content).toContain('<code>kiqr --help</code>');
+  });
+
+  it('renders the requested hostname client-side', () => {
+    const content = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(content).toContain('id="hostname"');
+    expect(content).toContain("document.getElementById('hostname').textContent = location.host");
+  });
+
+  it('links back to the Kiqr project', () => {
+    const content = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(content).toContain('https://github.com/kiqr');
+  });
+
+  it('is deterministic across writes', () => {
+    const first = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    const second = fs.readFileSync(writeSplashPage(tmp), 'utf-8');
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
Raises coverage on previously-untested pure modules ahead of upcoming refactors.

## What

Adds vitest unit tests for three pure `src/lib/` modules that had no `tests/lib/` counterpart:

- **`mu-plugin.ts`** — asserts the generated mu-plugin PHP includes theme auto-activation (by `KIQR_THEME_SLUG`, activate-once guard), signed-URL auto-login (`hash_equals` constant-time secret comparison, admin fallback, redirect + exit), and the injected LiveReload `<script>` tag with the configured port plus the `35729` default.
- **`splash.ts`** — asserts the splash HTML document structure and key markers (doctype, title, "No site is running" message, `kiqr up` / `kiqr --help` instructions, client-side hostname rendering, project link).
- **`nginx-splash.ts`** — asserts the catch-all nginx server config (`listen 80`, `server_name _`, html root, `try_files /splash.html =404`).

Each suite also checks the file-write contract (returned path, directory creation) and output determinism, mirroring the existing `tests/lib/` style.

## Risk

Tests only. No source changes — zero behavior risk.

## Verification

- `npm run typecheck` — pass
- `npm test` — 93 passed (17 files)
- `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)