### PR TITLE
docs: add CONTRIBUTING, issue/PR templates, and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include the full error output or a screenshot if helpful.
+
+## Environment
+
+- **Kiqr version** (`kiqr --version`):
+- **OS** (e.g. macOS 14.5, Ubuntu 24.04, Windows 11):
+- **Node version** (`node --version`):
+- **Docker version** (`docker --version`):
+
+## Additional context
+
+Add any other context, logs (`kiqr logs`), or relevant `kiqr.yaml` snippets here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for the Kiqr CLI
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem are you trying to solve? What's missing or frustrating today?
+
+## Proposed solution
+
+A clear and concise description of what you'd like to happen.
+
+## Alternatives considered
+
+Any alternative solutions or workarounds you've thought about.
+
+## Environment (if relevant)
+
+- **Kiqr version** (`kiqr --version`):
+- **OS** (e.g. macOS 14.5, Ubuntu 24.04, Windows 11):
+- **Docker version** (`docker --version`):
+
+## Additional context
+
+Add any other context, mockups, or examples here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation
+- [ ] Chore / tooling / refactor
+
+## How was this tested?
+
+<!-- Describe the tests you ran and/or the manual steps you took to verify. -->
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] `npm run build` passes
+- [ ] Code follows the project's style (see CONTRIBUTING.md)
+- [ ] Added or updated tests where it makes sense
+- [ ] Updated documentation where it makes sense

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Kiqr CLI
+
+Thanks for your interest in improving the Kiqr CLI! This guide covers everything
+you need to get a local development environment running and to land a change.
+
+The CLI is a TypeScript Node project built with [Pastel](https://github.com/vadimdemedes/pastel),
+[Ink](https://github.com/vadimdemedes/ink), and [React](https://react.dev),
+bundled with [tsup](https://tsup.egoist.dev) and tested with
+[Vitest](https://vitest.dev).
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) 18 or newer (CI runs on Node 20, 22, and 24)
+- npm (ships with Node)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) — only
+  required to run the CLI against a real WordPress environment, not for building
+  or testing the code itself
+
+## Setup
+
+```bash
+git clone https://github.com/kiqr/cli.git
+cd cli
+npm install
+```
+
+## Development loop
+
+| Command | What it does |
+|---------|--------------|
+| `npm run dev` | Rebuild the bundle on every change (tsup watch mode) |
+| `npm run build` | Produce the production bundle in `dist/` |
+| `npm test` | Run the test suite once (Vitest) |
+| `npm run test:watch` | Run Vitest in watch mode |
+| `npm run typecheck` | Type-check with `tsc --noEmit` (no emit) |
+
+A typical inner loop is to run `npm run test:watch` (or `npm run dev`) in one
+terminal while you edit.
+
+### Trying the CLI locally
+
+```bash
+npm run build
+node dist/cli.js --help
+```
+
+The `Makefile` mirrors the most common scripts (`make build`, `make test`,
+`make typecheck`) if you prefer make targets.
+
+## Coding standards
+
+- 2-space indentation, single quotes, no spacing inside braces (`{x}`, not
+  `{ x }`).
+- Use **named exports**.
+- Keep pure, side-effect-free logic in `src/lib/`. These functions should be
+  easy to unit test in isolation.
+- Put Ink/React components and command UIs in `src/commands/` (shared UI lives
+  in `src/components/`).
+- Prefer small, pure functions over stateful helpers wherever practical.
+
+### Linting and formatting
+
+Linting and formatting are handled by [Biome](https://biomejs.dev). Once it has
+landed (it may currently be arriving via an open pull request), run:
+
+```bash
+npm run lint     # check for lint issues
+npm run format   # apply formatting
+```
+
+If those scripts are not yet present in `package.json`, simply match the
+existing code style described above; the formatter will normalize it once Biome
+is wired up.
+
+## Branch and PR workflow
+
+1. Create a branch off `main` with a descriptive, kebab-case name. We use a
+   `type/short-description` convention, for example:
+   - `feat/doctor-command`
+   - `fix/chokidar-file-watcher`
+   - `docs/contributing-and-templates`
+2. Make focused commits. End each commit message body with a
+   `Co-Authored-By:` trailer when pairing or when a change is co-authored.
+3. Keep pull requests small and single-purpose — it makes review faster and
+   safer.
+4. Open a pull request against `main` using the
+   [pull request template](.github/PULL_REQUEST_TEMPLATE.md) and fill out the
+   checklist.
+
+## CI must pass
+
+Every pull request runs the [CI workflow](.github/workflows/ci.yml) across a
+matrix of **Node 20, 22, and 24**. Each job runs, in order:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+```
+
+Please make sure all three pass locally before pushing:
+
+```bash
+npm run typecheck && npm test && npm run build
+```
+
+Pull requests cannot be merged until CI is green.
+
+## Reporting bugs and requesting features
+
+Use the issue templates:
+
+- [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
+
+For bugs, please include your Kiqr version (`kiqr --version`), operating system,
+Docker version (`docker --version`), and clear reproduction steps.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+project's [MIT license](README.md#license).


### PR DESCRIPTION
## Summary

Pure additive documentation and tooling — no source changes. These files lower the contributor on-ramp toward the agency-standard goal of a self-service, well-documented repo.

## What's included

- **CONTRIBUTING.md** — setup (Node 18+, `npm install`), the dev loop (`npm run dev`/`build`/`test`/`typecheck`), coding standards, the Biome lint/format flow (referenced as `npm run lint`/`npm run format`, landing via #10), the branch + PR workflow, and the requirement that CI (typecheck/test/build on Node 20/22/24) must pass.
- **.github/ISSUE_TEMPLATE/bug_report.md** and **feature_request.md** — capture kiqr version, OS, Docker version, and repro/expected/actual.
- **.github/PULL_REQUEST_TEMPLATE.md** — summary, type of change, how tested, and a checklist including typecheck/test/build.
- **.editorconfig** — 2-space indent, LF, UTF-8, trim trailing whitespace, final newline (markdown keeps trailing whitespace for line breaks).

Everything was verified accurate against this repo's `package.json`, `Makefile`, and `.github/workflows/ci.yml`.

## How tested

No source changed, but verified the repo is still green:

- `npm run typecheck` passes
- `npm test` passes (70 tests, 14 files)
- `npm run build` passes

## Type of change

- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)