### PR TITLE
feat: validate WordPress × PHP image combo before pulling

### DIFF
--- a/src/commands/restart.tsx
+++ b/src/commands/restart.tsx
@@ -14,6 +14,7 @@ import {
   runDockerCompose,
 } from '../lib/docker.js';
 import {buildProjectHostname} from '../lib/hostname.js';
+import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
 import {
   getProjectPluginsDir,
@@ -149,6 +150,19 @@ export default function Restart() {
         if (lc.wordpress_version !== requestedVersion) {
           lc.wordpress_version = requestedVersion;
           writeLocalConfig(lc, ref.current.runtimeDir);
+        }
+      },
+    },
+    {
+      label: 'Validating WordPress + PHP version...',
+      run: async () => {
+        const pc = ref.current.projectConfig!;
+        const check = await validateWordPressPhp(
+          pc.wordpress.version,
+          pc.wordpress.php_version,
+        );
+        if (!check.ok) {
+          throw new Error(check.message);
         }
       },
     },

--- a/src/commands/up.tsx
+++ b/src/commands/up.tsx
@@ -22,6 +22,7 @@ import {
   runDockerCompose,
 } from '../lib/docker.js';
 import {buildProjectHostname} from '../lib/hostname.js';
+import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
 import {
   getProjectPluginsDir,
@@ -217,6 +218,19 @@ export default function Up() {
         if (lc.wordpress_version !== requestedVersion) {
           lc.wordpress_version = requestedVersion;
           writeLocalConfig(lc, ref.current.runtimeDir);
+        }
+      },
+    },
+    {
+      label: 'Validating WordPress + PHP version...',
+      run: async () => {
+        const pc = ref.current.projectConfig!;
+        const check = await validateWordPressPhp(
+          pc.wordpress.version,
+          pc.wordpress.php_version,
+        );
+        if (!check.ok) {
+          throw new Error(check.message);
         }
       },
     },

--- a/src/lib/image-tags.ts
+++ b/src/lib/image-tags.ts
@@ -1,0 +1,115 @@
+// Best-effort validation of the configured WordPress x PHP combination against
+// Docker Hub. Not every `wordpress:<version>-php<php>` tag is published (for
+// example `wordpress:6.4-php8.5` and `wordpress:6.7-php8.5` do not exist), so a
+// `docker compose pull` would otherwise fail with a confusing error.
+//
+// The Docker Hub HTTP fetch is injectable so this module can be unit-tested
+// without touching the network.
+
+const DOCKER_HUB_TAGS_URL =
+  'https://hub.docker.com/v2/repositories/library/wordpress/tags';
+
+/**
+ * Build the official `wordpress` image tag for a WordPress + PHP combination.
+ *
+ * Mirrors `BitnamiRuntimeProvider.getWordPressImage`'s tag scheme:
+ *   - `php8.3` for the latest WordPress on a given PHP version
+ *   - `6.7-php8.3` for a specific WordPress + PHP combination
+ */
+export function wordpressImageTag(version: string, php: string): string {
+  return version === 'latest' ? `php${php}` : `${version}-php${php}`;
+}
+
+/**
+ * Check whether a `wordpress` image tag exists on Docker Hub.
+ *
+ * Returns `true` on HTTP 200, `false` on HTTP 404, and `null` on any other
+ * status or thrown error. The `null` case is deliberate: this check is
+ * best-effort and an unknown/offline result must never block `kiqr up`.
+ */
+export async function wordpressTagExists(
+  tag: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean | null> {
+  try {
+    const res = await fetchImpl(`${DOCKER_HUB_TAGS_URL}/${tag}`);
+    if (res.status === 200) return true;
+    if (res.status === 404) return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List the PHP versions that ARE published for a given WordPress version.
+ *
+ * Queries Docker Hub for tags matching the relevant prefix (`php` for `latest`,
+ * otherwise `<version>-php`), extracts the `php8.x` portion from each tag name,
+ * and returns a sorted, de-duplicated list. Returns `[]` on any error.
+ */
+export async function availablePhpVersionsFor(
+  version: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[]> {
+  const prefix = version === 'latest' ? 'php' : `${version}-php`;
+  try {
+    const res = await fetchImpl(`${DOCKER_HUB_TAGS_URL}?page_size=100&name=${prefix}`);
+    if (!res.ok) return [];
+    const body = (await res.json()) as {results?: Array<{name?: string}>};
+    const results = body.results ?? [];
+    const versions = new Set<string>();
+    for (const result of results) {
+      const name = result.name;
+      if (!name) continue;
+      const match = name.match(/php(\d+\.\d+)/);
+      if (match?.[1]) versions.add(match[1]);
+    }
+    return Array.from(versions).sort();
+  } catch {
+    return [];
+  }
+}
+
+export interface WordPressTagCheck {
+  ok: boolean;
+  tag: string;
+  message?: string;
+  availablePhp?: string[];
+}
+
+/**
+ * Validate a configured WordPress + PHP combination against Docker Hub.
+ *
+ * Best-effort: if the tag's existence cannot be determined (network failure or
+ * unexpected response), the check passes so offline use is never blocked. The
+ * check only fails when Docker Hub positively reports the tag as missing.
+ */
+export async function validateWordPressPhp(
+  version: string,
+  php: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<WordPressTagCheck> {
+  const tag = wordpressImageTag(version, php);
+  const exists = await wordpressTagExists(tag, fetchImpl);
+
+  // Unknown (offline / unexpected status) or known-good: do not block.
+  if (exists === null || exists === true) return {ok: true, tag};
+
+  const availablePhp = await availablePhpVersionsFor(version, fetchImpl);
+  const label = version === 'latest' ? 'the latest WordPress' : `WordPress ${version}`;
+  const available =
+    availablePhp.length > 0
+      ? `Available PHP versions for ${label}: ${availablePhp.join(', ')}.`
+      : `No PHP-pinned tags were found for ${label} on Docker Hub.`;
+
+  return {
+    ok: false,
+    tag,
+    availablePhp,
+    message:
+      `The Docker image "wordpress:${tag}" does not exist on Docker Hub, so ${label} ` +
+      `is not published for PHP ${php}.\n${available}\n` +
+      'Update "wordpress.php_version" in kiqr.yaml to a supported version and try again.',
+  };
+}

--- a/tests/lib/image-tags.test.ts
+++ b/tests/lib/image-tags.test.ts
@@ -1,0 +1,213 @@
+import {describe, expect, it, vi} from 'vitest';
+import {
+  availablePhpVersionsFor,
+  validateWordPressPhp,
+  wordpressImageTag,
+  wordpressTagExists,
+} from '../../src/lib/image-tags.js';
+
+function mockResponse(init: {
+  status?: number;
+  ok?: boolean;
+  json?: () => Promise<unknown>;
+}): Response {
+  const status = init.status ?? 200;
+  return {
+    status,
+    ok: init.ok ?? (status >= 200 && status < 300),
+    json: init.json ?? (async () => ({})),
+  } as Response;
+}
+
+describe('wordpressImageTag', () => {
+  it('builds a PHP-only tag for the latest WordPress', () => {
+    expect(wordpressImageTag('latest', '8.3')).toBe('php8.3');
+  });
+
+  it('builds a version-pinned tag for a specific WordPress version', () => {
+    expect(wordpressImageTag('6.7', '8.3')).toBe('6.7-php8.3');
+  });
+
+  it('handles other PHP versions', () => {
+    expect(wordpressImageTag('6.4', '8.5')).toBe('6.4-php8.5');
+    expect(wordpressImageTag('latest', '8.2')).toBe('php8.2');
+  });
+});
+
+describe('wordpressTagExists', () => {
+  it('returns true on HTTP 200', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 200}));
+    await expect(wordpressTagExists('6.7-php8.3', fetchImpl)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://hub.docker.com/v2/repositories/library/wordpress/tags/6.7-php8.3',
+    );
+  });
+
+  it('returns false on HTTP 404', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 404}));
+    await expect(wordpressTagExists('6.7-php8.5', fetchImpl)).resolves.toBe(false);
+  });
+
+  it('returns null on an unexpected status (best-effort)', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 500}));
+    await expect(wordpressTagExists('6.7-php8.3', fetchImpl)).resolves.toBeNull();
+  });
+
+  it('returns null when fetch throws (offline)', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    await expect(wordpressTagExists('6.7-php8.3', fetchImpl)).resolves.toBeNull();
+  });
+});
+
+describe('availablePhpVersionsFor', () => {
+  it('parses, de-duplicates and sorts PHP versions for a pinned version', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({
+        status: 200,
+        json: async () => ({
+          results: [
+            {name: '6.7-php8.3'},
+            {name: '6.7-php8.2'},
+            {name: '6.7-php8.3-apache'},
+            {name: '6.7-php8.1-fpm'},
+          ],
+        }),
+      }),
+    );
+    await expect(availablePhpVersionsFor('6.7', fetchImpl)).resolves.toEqual([
+      '8.1',
+      '8.2',
+      '8.3',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://hub.docker.com/v2/repositories/library/wordpress/tags?page_size=100&name=6.7-php',
+    );
+  });
+
+  it('uses the php prefix for the latest version', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({
+        status: 200,
+        json: async () => ({results: [{name: 'php8.4'}, {name: 'php8.3'}]}),
+      }),
+    );
+    await expect(availablePhpVersionsFor('latest', fetchImpl)).resolves.toEqual([
+      '8.3',
+      '8.4',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://hub.docker.com/v2/repositories/library/wordpress/tags?page_size=100&name=php',
+    );
+  });
+
+  it('ignores tags without a php segment and entries without a name', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({
+        status: 200,
+        json: async () => ({
+          results: [{name: '6.7'}, {}, {name: '6.7-php8.3'}],
+        }),
+      }),
+    );
+    await expect(availablePhpVersionsFor('6.7', fetchImpl)).resolves.toEqual(['8.3']);
+  });
+
+  it('returns an empty list on a non-ok response', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 500, ok: false}));
+    await expect(availablePhpVersionsFor('6.7', fetchImpl)).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when fetch throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    await expect(availablePhpVersionsFor('6.7', fetchImpl)).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when results are missing', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({status: 200, json: async () => ({})}),
+    );
+    await expect(availablePhpVersionsFor('6.7', fetchImpl)).resolves.toEqual([]);
+  });
+});
+
+describe('validateWordPressPhp', () => {
+  it('passes when the tag exists', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 200}));
+    const result = await validateWordPressPhp('6.7', '8.3', fetchImpl);
+    expect(result).toEqual({ok: true, tag: '6.7-php8.3'});
+    // Should not need a second call to list available versions.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes (best-effort) when existence is unknown', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({status: 500}));
+    const result = await validateWordPressPhp('6.7', '8.3', fetchImpl);
+    expect(result).toEqual({ok: true, tag: '6.7-php8.3'});
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes (best-effort) when fetch throws (offline)', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    const result = await validateWordPressPhp('6.7', '8.5', fetchImpl);
+    expect(result).toEqual({ok: true, tag: '6.7-php8.5'});
+  });
+
+  it('fails and lists available PHP versions when the tag is missing', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith('/tags/6.7-php8.5')) {
+        return mockResponse({status: 404});
+      }
+      return mockResponse({
+        status: 200,
+        json: async () => ({
+          results: [{name: '6.7-php8.2'}, {name: '6.7-php8.3'}, {name: '6.7-php8.4'}],
+        }),
+      });
+    });
+
+    const result = await validateWordPressPhp('6.7', '8.5', fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.tag).toBe('6.7-php8.5');
+    expect(result.availablePhp).toEqual(['8.2', '8.3', '8.4']);
+    expect(result.message).toContain('wordpress:6.7-php8.5');
+    expect(result.message).toContain('8.2, 8.3, 8.4');
+    expect(result.message).toContain('kiqr.yaml');
+  });
+
+  it('fails gracefully when the missing tag has no listable alternatives', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.includes('/tags/')) return mockResponse({status: 404});
+      return mockResponse({status: 200, json: async () => ({results: []})});
+    });
+
+    const result = await validateWordPressPhp('6.7', '8.5', fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.availablePhp).toEqual([]);
+    expect(result.message).toContain('No PHP-pinned tags');
+  });
+
+  it('reports the latest-version label for missing latest tags', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.includes('/tags/')) return mockResponse({status: 404});
+      return mockResponse({
+        status: 200,
+        json: async () => ({results: [{name: 'php8.3'}, {name: 'php8.4'}]}),
+      });
+    });
+
+    const result = await validateWordPressPhp('latest', '8.9', fetchImpl);
+    expect(result.ok).toBe(false);
+    expect(result.tag).toBe('php8.9');
+    expect(result.message).toContain('the latest WordPress');
+    expect(result.availablePhp).toEqual(['8.3', '8.4']);
+  });
+});


### PR DESCRIPTION
## What

Adds a best-effort preflight that validates the configured WordPress × PHP combination against Docker Hub **before** `kiqr up` (and `kiqr restart`) try to pull the image.

Not every `wordpress:<ver>-php<php>` tag is published — for example `wordpress:6.4-php8.5` and `wordpress:6.7-php8.5` do **not** exist — so a `docker compose pull` would otherwise fail with a confusing low-level error. This directly addresses the WordPress × PHP combo concern raised in review on the merged #13.

## How

New `src/lib/image-tags.ts` — pure and fetch-injectable so it is unit-testable without the network:

- `wordpressImageTag(version, php)` — mirrors `BitnamiRuntimeProvider.getWordPressImage`'s tag scheme (`php8.3` for latest, `6.7-php8.3` for a pinned version).
- `wordpressTagExists(tag, fetchImpl)` — `GET /v2/repositories/library/wordpress/tags/<tag>`; `200 → true`, `404 → false`, **any other status or thrown error → `null`**.
- `availablePhpVersionsFor(version, fetchImpl)` — lists the PHP versions that ARE published for a WordPress version (sorted, de-duplicated); `[]` on error.
- `validateWordPressPhp(version, php, fetchImpl)` — returns `{ok, tag, message?, availablePhp?}`.

Wired into `up.tsx` and `restart.tsx` as a `StepRunner` step ("Validating WordPress + PHP version…") that runs **before** the docker compose up step. It throws the actionable `.message` when the combo is confirmed missing, pointing the user to fix `wordpress.php_version` in `kiqr.yaml`. **Docker invocation logic is unchanged.**

### Best-effort by design (never blocks offline)

The check only fails on a **positively confirmed** missing tag (HTTP 404). Any unknown result — network failure, offline, rate-limit, unexpected status — resolves to `null` and the step passes, so `kiqr up` is never blocked by Docker Hub being unreachable.

## Tests

`tests/lib/image-tags.test.ts` uses an injected mock fetch (no network): tag-building combos, `wordpressTagExists` (200/404/500/throw), `availablePhpVersionsFor` parsing/sorting/error paths, and `validateWordPressPhp` for exists→ok, missing→`{ok:false}` listing available PHP, and network-null→ok.

`npm run typecheck`, `npm test` (130 passing), and `npm run build` all green.

Note: this PR intentionally does **not** add Biome or `biome.json`; the new/changed code is written to match the style in #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)