### PR TITLE
feat: add kiqr completion command (bash/zsh/fish)

### DIFF
--- a/src/commands/completion.tsx
+++ b/src/commands/completion.tsx
@@ -1,0 +1,41 @@
+import {Text} from 'ink';
+import {argument} from 'pastel';
+import zod from 'zod';
+import {
+  COMPLETION_SHELLS,
+  generateCompletion,
+  isCompletionShell,
+  KIQR_COMMANDS,
+} from '../lib/completion.js';
+
+export const description = 'Print a shell completion script (bash/zsh/fish)';
+
+export const args = zod.tuple([
+  zod.enum(COMPLETION_SHELLS).describe(
+    argument({
+      name: 'shell',
+      description: `Shell to generate completion for (${COMPLETION_SHELLS.join(', ')})`,
+    }),
+  ),
+]);
+
+type Props = {args: zod.infer<typeof args>};
+
+export default function Completion({args}: Props) {
+  const shell = args[0];
+
+  // zod already validates against COMPLETION_SHELLS, but guard defensively so a
+  // bad value produces a clear message instead of an opaque crash.
+  if (!isCompletionShell(shell)) {
+    return (
+      <Text color="red">
+        Unsupported shell "{shell}". Supported shells: {COMPLETION_SHELLS.join(', ')}.
+      </Text>
+    );
+  }
+
+  // Print the raw script to stdout so it can be piped/redirected:
+  //   kiqr completion bash >> ~/.bashrc
+  const script = generateCompletion(shell, [...KIQR_COMMANDS]);
+  return <Text>{script}</Text>;
+}

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -1,0 +1,100 @@
+export const COMPLETION_SHELLS = ['bash', 'zsh', 'fish'] as const;
+
+export type CompletionShell = (typeof COMPLETION_SHELLS)[number];
+
+/**
+ * Stable, top-level kiqr subcommands offered by shell completion.
+ *
+ * This is a hardcoded list rather than auto-discovery so that the generated
+ * completion script is deterministic and does not depend on the CLI being
+ * able to run (the user's shell sources it on startup).
+ */
+export const KIQR_COMMANDS = [
+  'up',
+  'down',
+  'restart',
+  'init',
+  'info',
+  'open',
+  'logs',
+  'wp',
+  'watch',
+  'destroy',
+  'doctor',
+  'db',
+] as const;
+
+/**
+ * Type guard for validating an arbitrary string against the supported shells.
+ */
+export function isCompletionShell(value: string): value is CompletionShell {
+  return (COMPLETION_SHELLS as readonly string[]).includes(value);
+}
+
+function generateBash(commands: string[]): string {
+  const wordList = commands.join(' ');
+  return `# kiqr bash completion
+# Install: kiqr completion bash >> ~/.bashrc
+_kiqr_completion() {
+  local cur cmds
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  cmds="${wordList}"
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
+  fi
+  return 0
+}
+complete -F _kiqr_completion kiqr
+`;
+}
+
+function generateZsh(commands: string[]): string {
+  const lines = commands.map((c) => `    '${c}'`).join(' \\\n');
+  return `#compdef kiqr
+# kiqr zsh completion
+# Install: kiqr completion zsh > "\${fpath[1]}/_kiqr"
+_kiqr() {
+  local -a commands
+  commands=(
+${lines}
+  )
+  if (( CURRENT == 2 )); then
+    compadd -- \${commands}
+  fi
+}
+compdef _kiqr kiqr
+`;
+}
+
+function generateFish(commands: string[]): string {
+  const lines = commands
+    .map((c) => `complete -c kiqr -n '__fish_use_subcommand' -f -a '${c}'`)
+    .join('\n');
+  return `# kiqr fish completion
+# Install: kiqr completion fish > ~/.config/fish/completions/kiqr.fish
+${lines}
+`;
+}
+
+/**
+ * Generate an idiomatic shell completion script for `kiqr`.
+ *
+ * The returned script completes the given top-level subcommand names directly
+ * after `kiqr` (i.e. the first argument).
+ */
+export function generateCompletion(shell: CompletionShell, commands: string[]): string {
+  switch (shell) {
+    case 'bash':
+      return generateBash(commands);
+    case 'zsh':
+      return generateZsh(commands);
+    case 'fish':
+      return generateFish(commands);
+    default: {
+      // Exhaustiveness guard: if a new shell is added to the union without a
+      // matching branch, TypeScript flags this and we fail loudly at runtime.
+      const _exhaustive: never = shell;
+      throw new Error(`Unsupported shell: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/tests/lib/completion.test.ts
+++ b/tests/lib/completion.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it} from 'vitest';
+import {
+  COMPLETION_SHELLS,
+  type CompletionShell,
+  generateCompletion,
+  isCompletionShell,
+  KIQR_COMMANDS,
+} from '../../src/lib/completion.js';
+
+const COMMANDS = [...KIQR_COMMANDS];
+
+describe('COMPLETION_SHELLS', () => {
+  it('lists exactly bash, zsh, and fish', () => {
+    expect(COMPLETION_SHELLS).toEqual(['bash', 'zsh', 'fish']);
+  });
+});
+
+describe('KIQR_COMMANDS', () => {
+  it('includes the stable top-level commands', () => {
+    for (const cmd of [
+      'up',
+      'down',
+      'restart',
+      'init',
+      'info',
+      'open',
+      'logs',
+      'wp',
+      'watch',
+      'destroy',
+      'doctor',
+      'db',
+    ]) {
+      expect(KIQR_COMMANDS).toContain(cmd);
+    }
+  });
+});
+
+describe('isCompletionShell', () => {
+  it('accepts supported shells', () => {
+    for (const shell of COMPLETION_SHELLS) {
+      expect(isCompletionShell(shell)).toBe(true);
+    }
+  });
+
+  it('rejects unknown shells', () => {
+    expect(isCompletionShell('powershell')).toBe(false);
+    expect(isCompletionShell('')).toBe(false);
+    expect(isCompletionShell('BASH')).toBe(false);
+  });
+});
+
+describe('generateCompletion', () => {
+  for (const shell of COMPLETION_SHELLS) {
+    describe(shell, () => {
+      const script = generateCompletion(shell, COMMANDS);
+
+      it('returns a non-empty script', () => {
+        expect(script.length).toBeGreaterThan(0);
+        expect(script.trim()).not.toBe('');
+      });
+
+      it('contains every command name', () => {
+        for (const cmd of COMMANDS) {
+          expect(script).toContain(cmd);
+        }
+      });
+    });
+  }
+
+  it('emits the bash-specific marker (complete -F)', () => {
+    const script = generateCompletion('bash', COMMANDS);
+    expect(script).toContain('complete -F');
+    expect(script).toContain('_kiqr_completion');
+    expect(script).toContain('compgen -W');
+  });
+
+  it('emits the zsh-specific marker (compdef)', () => {
+    const script = generateCompletion('zsh', COMMANDS);
+    expect(script).toContain('#compdef kiqr');
+    expect(script).toContain('compdef _kiqr kiqr');
+  });
+
+  it('emits the fish-specific marker (complete -c)', () => {
+    const script = generateCompletion('fish', COMMANDS);
+    expect(script).toContain('complete -c kiqr');
+    expect(script).toContain('__fish_use_subcommand');
+  });
+
+  it('reflects a custom command list rather than hardcoding', () => {
+    const custom = ['alpha', 'beta'];
+    const script = generateCompletion('bash', custom);
+    expect(script).toContain('alpha');
+    expect(script).toContain('beta');
+    expect(script).not.toContain('destroy');
+  });
+
+  it('throws on an unsupported shell', () => {
+    expect(() => generateCompletion('powershell' as CompletionShell, COMMANDS)).toThrow(
+      /Unsupported shell/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a new `kiqr completion <bash|zsh|fish>` command that prints an idiomatic shell completion script to stdout. Sourcing it gives tab-completion for kiqr's top-level subcommands (`up`, `down`, `restart`, `init`, `info`, `open`, `logs`, `wp`, `watch`, `destroy`, `doctor`, `db`).

## Why (the DX win)

Typing `kiqr <TAB>` and getting the available commands is a meaningful quality-of-life improvement, especially while learning the CLI. The completion script is fully static and deterministic, so the shell can source it on startup without invoking the CLI.

## Install

```bash
# bash
kiqr completion bash >> ~/.bashrc

# zsh (drop into an fpath dir)
kiqr completion zsh > "${fpath[1]}/_kiqr"

# fish
kiqr completion fish > ~/.config/fish/completions/kiqr.fish
```

## Design

- `src/lib/completion.ts` — pure, unit-tested generation. Exports `COMPLETION_SHELLS`, `CompletionShell`, `KIQR_COMMANDS`, `isCompletionShell`, and `generateCompletion(shell, commands)`. Each shell gets its idiomatic markers (`complete -F` for bash, `#compdef`/`compdef` for zsh, `complete -c ... __fish_use_subcommand` for fish).
- `src/commands/completion.tsx` — thin Pastel command. The `shell` positional arg is a zod enum over `COMPLETION_SHELLS`, so unsupported shells produce a clear validation error with the allowed choices.
- `tests/lib/completion.test.ts` — asserts each shell returns a non-empty script containing every command name plus the right shell-specific markers, custom command lists are honored, and unknown shells are rejected.

No new files touch shared modules (`index.tsx`/`README.md`); Pastel auto-discovers the command.

## Verification

- `npm run typecheck`, `npm test` (126 passing), `npm run build`, `npm run lint` all green.
- Smoke-tested the built CLI for all three shells plus an invalid shell (clean error, exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)