### PR TITLE
feat: add kiqr status command

### DIFF
--- a/src/commands/status.tsx
+++ b/src/commands/status.tsx
@@ -1,0 +1,90 @@
+import {Box, Text, useApp} from 'ink';
+import {useEffect, useState} from 'react';
+import {isContainerRunning} from '../lib/docker.js';
+import {
+  getProjectStatus,
+  type ProjectStatus,
+  serviceFromContainerName,
+} from '../lib/status.js';
+
+export const description = 'Show whether the project is running and where to reach it';
+
+function StatusDot({running}: {running: boolean}) {
+  return running ? <Text color="green">●</Text> : <Text color="red">○</Text>;
+}
+
+export default function Status() {
+  const {exit} = useApp();
+  const [status, setStatus] = useState<ProjectStatus | null>(null);
+
+  useEffect(() => {
+    setStatus(getProjectStatus({isContainerRunning}));
+    setTimeout(() => exit(), 50);
+  }, []);
+
+  if (!status) return <Text dimColor>Checking status...</Text>;
+
+  if (!status.initialized) {
+    return (
+      <Box paddingTop={1}>
+        <Text color="red">This project is not initialized. Run "kiqr init" first.</Text>
+      </Box>
+    );
+  }
+
+  const labelW = Math.max(
+    ...status.containers.map((c) => serviceFromContainerName(c.name).length),
+  );
+
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      <Text>
+        <Text bold>Status: </Text>
+        {status.running ? (
+          <Text color="green" bold>
+            running
+          </Text>
+        ) : (
+          <Text color="red" bold>
+            stopped
+          </Text>
+        )}
+      </Text>
+      <Text> </Text>
+
+      <Text bold>Services</Text>
+      {status.containers.map((c) => (
+        <Text key={c.name}>
+          {' '}
+          <StatusDot running={c.running} />{' '}
+          {serviceFromContainerName(c.name).padEnd(labelW)}{' '}
+          <Text dimColor>{c.running ? 'running' : 'stopped'}</Text>
+        </Text>
+      ))}
+
+      {status.urls ? (
+        <>
+          <Text> </Text>
+          <Text bold>URLs</Text>
+          <Text>
+            {' '}
+            Site: <Text color="cyan">{status.urls.site}</Text>
+          </Text>
+          <Text>
+            {' '}
+            Admin: <Text color="cyan">{status.urls.admin}</Text>
+          </Text>
+          <Text>
+            {' '}
+            phpMyAdmin: <Text color="cyan">{status.urls.phpmyadmin}</Text>
+          </Text>
+        </>
+      ) : (
+        <>
+          <Text> </Text>
+          <Text dimColor>Start the project with: kiqr up</Text>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -1,0 +1,106 @@
+import {readProjectConfig} from './config.js';
+import {buildProjectHostname} from './hostname.js';
+
+/**
+ * The user-facing services that make up a running Kiqr project. The mariadb
+ * service is included because the site is not truly "up" without it, and
+ * surfacing it helps diagnose a stuck/partial start.
+ */
+export const STATUS_SERVICES = ['wordpress', 'mariadb', 'phpmyadmin'] as const;
+
+export type StatusService = (typeof STATUS_SERVICES)[number];
+
+export interface ContainerStatus {
+  name: string;
+  running: boolean;
+}
+
+export interface ProjectStatus {
+  initialized: boolean;
+  running: boolean;
+  containers: ContainerStatus[];
+  urls?: {
+    site: string;
+    admin: string;
+    phpmyadmin: string;
+  };
+}
+
+export interface ProjectStatusDeps {
+  /**
+   * Returns true when a container whose name contains `name` is running.
+   * Injected so the Docker call can be mocked in tests. Defaults to nothing
+   * here on purpose — callers must supply it.
+   */
+  isContainerRunning: (name: string) => boolean;
+  /** Read the project config. Injected so fs access can be controlled in tests. */
+  readProjectConfig?: (dir?: string) => ReturnType<typeof readProjectConfig>;
+  /** Working directory to resolve the project config from. */
+  cwd?: string;
+}
+
+/**
+ * Build the docker compose default container name for a service.
+ *
+ * The project compose file lives in a directory named after the project id, so
+ * Compose names containers `<project_id>-<service>-<n>`. `isContainerRunning`
+ * matches on a name substring, so the `<project_id>-<service>` prefix is a
+ * precise, instance-number-agnostic filter.
+ */
+export function containerNameFor(projectId: string, service: StatusService): string {
+  return `${projectId}-${service}`;
+}
+
+/**
+ * Recover the bare service name from a `<project_id>-<service>` container name
+ * for display, regardless of whether the project id itself contains hyphens.
+ * Falls back to the full name if no known service suffix matches.
+ */
+export function serviceFromContainerName(name: string): string {
+  const match = STATUS_SERVICES.find((service) => name.endsWith(`-${service}`));
+  return match ?? name;
+}
+
+/**
+ * Compute a project's live status: whether it is initialized, whether each
+ * service container is running, the overall running state, and the URLs to
+ * reach it (only when the site is up).
+ *
+ * Pure aside from the injected `isContainerRunning` check and the config read.
+ */
+export function getProjectStatus(deps: ProjectStatusDeps): ProjectStatus {
+  const readConfig = deps.readProjectConfig ?? readProjectConfig;
+  const pc = readConfig(deps.cwd);
+
+  if (!pc) {
+    return {initialized: false, running: false, containers: []};
+  }
+
+  const containers: ContainerStatus[] = STATUS_SERVICES.map((service) => {
+    const name = containerNameFor(pc.project_id, service);
+    return {name, running: deps.isContainerRunning(name)};
+  });
+
+  // The site is "running" when the WordPress front-end container is up. The
+  // other services are reported individually so a partial state is visible.
+  const wordpressName = containerNameFor(pc.project_id, 'wordpress');
+  const running = containers.find((c) => c.name === wordpressName)?.running ?? false;
+
+  const status: ProjectStatus = {
+    initialized: true,
+    running,
+    containers,
+  };
+
+  if (running) {
+    const hostname = buildProjectHostname(pc.name);
+    const phpMyAdminHostname = buildProjectHostname(pc.name, 'phpmyadmin');
+    status.urls = {
+      site: `http://${hostname}:5477`,
+      admin: `http://${hostname}:5477/wp-admin`,
+      phpmyadmin: `http://${phpMyAdminHostname}:5477`,
+    };
+  }
+
+  return status;
+}

--- a/tests/lib/status.test.ts
+++ b/tests/lib/status.test.ts
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {writeProjectConfig} from '../../src/lib/config.js';
+import {
+  containerNameFor,
+  getProjectStatus,
+  serviceFromContainerName,
+} from '../../src/lib/status.js';
+import type {ProjectConfig} from '../../src/types/config.js';
+
+// buildProjectHostname embeds the machine hostname; pin it so URL assertions
+// are deterministic regardless of the host the test runs on.
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {...actual, default: {...actual, hostname: () => 'testbox'}};
+});
+
+const PROJECT: ProjectConfig = {
+  project_id: 'proj-123',
+  name: 'acme',
+  wordpress: {version: 'latest', php_version: '8.3'},
+  development: {dynamic_urls: true},
+};
+
+describe('containerNameFor', () => {
+  it('joins the project id and service name', () => {
+    expect(containerNameFor('proj-123', 'wordpress')).toBe('proj-123-wordpress');
+    expect(containerNameFor('proj-123', 'mariadb')).toBe('proj-123-mariadb');
+    expect(containerNameFor('proj-123', 'phpmyadmin')).toBe('proj-123-phpmyadmin');
+  });
+});
+
+describe('serviceFromContainerName', () => {
+  it('recovers the service name even when the project id has hyphens', () => {
+    expect(serviceFromContainerName('smoke-proj-wordpress')).toBe('wordpress');
+    expect(serviceFromContainerName('proj-123-mariadb')).toBe('mariadb');
+    expect(serviceFromContainerName('a-b-c-phpmyadmin')).toBe('phpmyadmin');
+  });
+
+  it('falls back to the full name when no known service matches', () => {
+    expect(serviceFromContainerName('kiqr-traefik')).toBe('kiqr-traefik');
+  });
+});
+
+describe('getProjectStatus', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiqr-status-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('reports not initialized when there is no project config', () => {
+    const isContainerRunning = vi.fn(() => true);
+    const status = getProjectStatus({isContainerRunning, cwd: tmpDir});
+
+    expect(status).toEqual({initialized: false, running: false, containers: []});
+    // No point querying Docker for a project that does not exist.
+    expect(isContainerRunning).not.toHaveBeenCalled();
+  });
+
+  it('reports running with URLs when the wordpress container is up', () => {
+    writeProjectConfig(PROJECT, tmpDir);
+    const isContainerRunning = vi.fn(() => true);
+
+    const status = getProjectStatus({isContainerRunning, cwd: tmpDir});
+
+    expect(status.initialized).toBe(true);
+    expect(status.running).toBe(true);
+    expect(status.containers).toEqual([
+      {name: 'proj-123-wordpress', running: true},
+      {name: 'proj-123-mariadb', running: true},
+      {name: 'proj-123-phpmyadmin', running: true},
+    ]);
+    expect(status.urls).toEqual({
+      site: 'http://acme.testbox.lvh.me:5477',
+      admin: 'http://acme.testbox.lvh.me:5477/wp-admin',
+      phpmyadmin: 'http://phpmyadmin.acme.testbox.lvh.me:5477',
+    });
+  });
+
+  it('queries one container per service using the compose name prefix', () => {
+    writeProjectConfig(PROJECT, tmpDir);
+    const isContainerRunning = vi.fn(() => false);
+
+    getProjectStatus({isContainerRunning, cwd: tmpDir});
+
+    expect(isContainerRunning.mock.calls.map((c) => c[0])).toEqual([
+      'proj-123-wordpress',
+      'proj-123-mariadb',
+      'proj-123-phpmyadmin',
+    ]);
+  });
+
+  it('reports stopped and omits URLs when wordpress is down', () => {
+    writeProjectConfig(PROJECT, tmpDir);
+    const isContainerRunning = vi.fn(() => false);
+
+    const status = getProjectStatus({isContainerRunning, cwd: tmpDir});
+
+    expect(status.running).toBe(false);
+    expect(status.urls).toBeUndefined();
+    expect(status.containers.every((c) => !c.running)).toBe(true);
+  });
+
+  it('treats the site as stopped when only support services run', () => {
+    writeProjectConfig(PROJECT, tmpDir);
+    // mariadb + phpmyadmin up, wordpress down (a partial / stuck start).
+    const isContainerRunning = vi.fn((name: string) => !name.endsWith('-wordpress'));
+
+    const status = getProjectStatus({isContainerRunning, cwd: tmpDir});
+
+    expect(status.running).toBe(false);
+    expect(status.urls).toBeUndefined();
+    expect(status.containers).toEqual([
+      {name: 'proj-123-wordpress', running: false},
+      {name: 'proj-123-mariadb', running: true},
+      {name: 'proj-123-phpmyadmin', running: true},
+    ]);
+  });
+
+  it('uses an injected readProjectConfig when provided', () => {
+    const isContainerRunning = vi.fn(() => true);
+    const readProjectConfig = vi.fn(() => PROJECT);
+
+    const status = getProjectStatus({isContainerRunning, readProjectConfig});
+
+    expect(readProjectConfig).toHaveBeenCalled();
+    expect(status.initialized).toBe(true);
+    expect(status.running).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds `kiqr status` — a live project status dashboard that answers the
single most common question during local theme dev: **"is my site up,
and where do I reach it?"** — at a glance, without digging through
`docker ps` or remembering the per-project hostname scheme.

Running `kiqr status` shows:

- whether the project is **initialized** (`kiqr.yaml` present),
- an overall **running / stopped** state (green / red),
- the **per-service container** state (wordpress, mariadb, phpmyadmin),
  so a partial or stuck start is immediately visible,
- the **URLs** (site, admin, phpMyAdmin) — only when the site is up.

```
Status: running

Services
 ● wordpress  running
 ● mariadb    running
 ● phpmyadmin running

URLs
 Site: http://acme.<machine>.lvh.me:5477
 Admin: http://acme.<machine>.lvh.me:5477/wp-admin
 phpMyAdmin: http://phpmyadmin.acme.<machine>.lvh.me:5477
```

When stopped it nudges you toward `kiqr up`; when uninitialized it
points at `kiqr init`.

## How

- `src/lib/status.ts` — pure, unit-tested logic. `getProjectStatus(deps)`
  reads the project config and resolves each service's running state via
  the existing `isContainerRunning` from `src/lib/docker.ts`, **injected
  as a dependency** so it is fully mockable. URLs are computed with
  `buildProjectHostname` and the exact `:5477` scheme used by
  `info.tsx` / `open.tsx`. The overall running state keys off the
  WordPress front-end container.
- `src/commands/status.tsx` — a thin Ink renderer mirroring the style of
  `info.tsx` (Pastel auto-discovers it; no `index.tsx` edit needed).
- `tests/lib/status.test.ts` — injects a mock container-check fn and a
  temp `kiqr.yaml`; asserts not-initialized / running-with-URLs /
  stopped / partial-start states, URL computation, and the container
  name filtering.

## Verification

- `npm run lint` (Biome) — pass
- `npm run typecheck` — pass
- `npm test` — pass (120 tests, 9 new)
- `npm run build` — pass
- Smoke-tested `node dist/cli.js status` end-to-end in initialized
  (stopped) and uninitialized project dirs; output as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)