### PR TITLE
fix: handle invalid config gracefully in info/logs/open/db-list/watch

### DIFF
--- a/src/commands/db/list.tsx
+++ b/src/commands/db/list.tsx
@@ -29,7 +29,14 @@ export default function DbList() {
 
   useEffect(() => {
     (async () => {
-      const pc = readProjectConfig();
+      let pc: ReturnType<typeof readProjectConfig>;
+      try {
+        pc = readProjectConfig();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setTimeout(() => exit(new Error()), 100);
+        return;
+      }
       if (!pc) {
         setError('This project is not initialized. Run "kiqr init" first.');
         setTimeout(() => exit(new Error()), 100);

--- a/src/commands/info.tsx
+++ b/src/commands/info.tsx
@@ -8,18 +8,39 @@ export const description = 'Show project info and credentials';
 export default function Info() {
   const {exit} = useApp();
 
-  const pc = readProjectConfig();
-  if (!pc) {
+  let result:
+    | {
+        ok: true;
+        pc: NonNullable<ReturnType<typeof readProjectConfig>>;
+        lc: ReturnType<typeof readLocalConfig>;
+      }
+    | {ok: false; message: string | null};
+  try {
+    const pc = readProjectConfig();
+    if (!pc) {
+      result = {ok: false, message: null};
+    } else {
+      const lc = readLocalConfig(getProjectRuntimeDir(pc.project_id));
+      result = {ok: true, pc, lc};
+    }
+  } catch (err) {
+    result = {ok: false, message: err instanceof Error ? err.message : String(err)};
+  }
+
+  if (!result.ok) {
+    const message =
+      result.message ?? 'This project is not initialized. Run "kiqr init" first.';
+    if (result.message !== null) {
+      setTimeout(() => exit(new Error(message)), 50);
+    }
     return (
       <Box paddingTop={1}>
-        <Text color="red">This project is not initialized. Run "kiqr init" first.</Text>
+        <Text color="red">{message}</Text>
       </Box>
     );
   }
 
-  const runtimeDir = getProjectRuntimeDir(pc.project_id);
-  const lc = readLocalConfig(runtimeDir);
-
+  const {pc, lc} = result;
   const hostname = buildProjectHostname(pc.name);
   const phpMyAdminHostname = buildProjectHostname(pc.name, 'phpmyadmin');
 

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -11,7 +11,14 @@ export default function Logs() {
   const {exit} = useApp();
 
   useEffect(() => {
-    const pc = readProjectConfig();
+    let pc: ReturnType<typeof readProjectConfig>;
+    try {
+      pc = readProjectConfig();
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      exit(new Error());
+      return;
+    }
     if (!pc) {
       console.error('This project is not initialized. Run "kiqr init" first.');
       exit(new Error());

--- a/src/commands/open.tsx
+++ b/src/commands/open.tsx
@@ -67,7 +67,14 @@ export default function Open({args}: Props) {
   const [appArg] = args;
 
   useEffect(() => {
-    const pc = readProjectConfig();
+    let pc: ReturnType<typeof readProjectConfig>;
+    try {
+      pc = readProjectConfig();
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      exit(new Error());
+      return;
+    }
     if (!pc) {
       console.error('This project is not initialized. Run "kiqr init" first.');
       exit(new Error());
@@ -84,7 +91,14 @@ export default function Open({args}: Props) {
     }
 
     const runtimeDir = getProjectRuntimeDir(pc.project_id);
-    const lc = readLocalConfig(runtimeDir);
+    let lc: ReturnType<typeof readLocalConfig>;
+    try {
+      lc = readLocalConfig(runtimeDir);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      exit(new Error());
+      return;
+    }
     const hostname = buildProjectHostname(pc.name);
     const phpMyAdminHostname = buildProjectHostname(pc.name, 'phpmyadmin');
 

--- a/src/commands/watch.tsx
+++ b/src/commands/watch.tsx
@@ -28,7 +28,13 @@ export default function Watch() {
     let mounted = true;
 
     async function startWatch() {
-      const pc = readProjectConfig();
+      let pc: ReturnType<typeof readProjectConfig>;
+      try {
+        pc = readProjectConfig();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        return;
+      }
       if (!pc) {
         setError('This project is not initialized. Run "kiqr init" first.');
         return;


### PR DESCRIPTION
## Problem

After zod validation was added, `readProjectConfig()` / `readLocalConfig()` (`src/lib/config.ts`) now **throw** when `kiqr.yaml` / `config.yaml` exists but is invalid (bad YAML or schema mismatch). Several commands call these without a try/catch, so they crash with an unhandled error and a raw stack trace instead of showing the friendly message.

Affected commands: `info`, `logs`, `open`, `db list`, `watch`.

(`up`/`down`/`restart`/`destroy` already route config errors through `StepRunner`; `wp` is addressed separately.)

## Fix

Wrap the config read(s) in each affected command in try/catch and surface the error via that command's existing error path:

- `info.tsx` — renders a red error `Text` and exits with an error (the component reads config in its render body).
- `logs.tsx`, `open.tsx` — `console.error(message)` + `exit(new Error())`, matching their existing "not initialized" handling.
- `db/list.tsx` — `setError(message)` + `exit(new Error())`.
- `watch.tsx` — `setError(message)` into its existing error Box.

Each keeps the existing "not initialized" (null config) behavior intact.

## Tests

The lib-level `tests/lib/config.test.ts` already asserts that `readProjectConfig`/`readLocalConfig` throw clear errors on malformed YAML, missing fields, and wrong field types (for both project and local config), which is the behavior these commands now handle. The command files are Ink components; no brittle UI tests were added.

## Gates

- `npm run typecheck` ✅
- `npm test` ✅ (192 passed)
- `npm run build` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)