### PR TITLE
fix: drain wp db import stdout to prevent restore deadlock

### DIFF
--- a/src/commands/db/restore.tsx
+++ b/src/commands/db/restore.tsx
@@ -79,6 +79,10 @@ async function runRestore(
   const child = spawnWpCli(composePath, ['wp', 'db', 'import', '-']);
   const stderrChunks: Buffer[] = [];
   child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
+  // Drain stdout. We don't use its content (errors come from stderr), but if
+  // the child writes more than the OS pipe buffer (~64KB) and nothing reads
+  // it, the child blocks on write and the import deadlocks.
+  child.stdout.resume();
   const src = storage.openRead(record).pipe(createGunzip());
   src.pipe(child.stdin);
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Problem

`src/commands/db/restore.tsx` spawns `wp db import -` via `spawnWpCli`, which uses `stdio: ['pipe', 'pipe', 'pipe']`, but it **never reads or drains the child's stdout**. If the child writes more than the OS pipe buffer (~64KB) and nothing consumes it, the child blocks on write and the restore **deadlocks**.

By contrast, the dump path consumes the child's stdout (`child.stdout.pipe(createGzip())`), so it never hits this.

## Fix

Restore only surfaces **stderr** (that's what the error message is built from); the child's stdout content is not used. So we drain it with `child.stdout.resume()`, which puts the stream into flowing mode and discards the data, keeping the pipe buffer empty. Error handling and the close/error promise wiring are unchanged.

## Tests

The restore flow lives inside an Ink component and spawns a real `docker` child; there is no existing harness to unit-test that spawn wiring without substantial mocking, so no brittle test was added. All existing tests pass (192).

## Gates

- `npm run typecheck` ✅
- `npm test` ✅ (192 passed)
- `npm run build` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)