### PR TITLE
feat: simplify local hostname to <slug>.lvh.me

### DIFF
--- a/src/lib/hostname.ts
+++ b/src/lib/hostname.ts
@@ -15,8 +15,9 @@ export function sanitizeHostname(raw: string): string {
 }
 
 export function buildProjectHostname(projectSlug: string, subdomain?: string): string {
-  const machine = getMachineHostname();
-  const base = `${projectSlug}.${machine}.lvh.me`;
+  // lvh.me always resolves to 127.0.0.1, so the project slug alone is enough
+  // for a unique, easy-to-type local hostname — no machine segment needed.
+  const base = `${projectSlug}.lvh.me`;
   if (subdomain) {
     return `${subdomain}.${base}`;
   }

--- a/tests/lib/hostname.test.ts
+++ b/tests/lib/hostname.test.ts
@@ -1,13 +1,5 @@
-import os from 'node:os';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 import {buildProjectHostname, sanitizeHostname} from '../../src/lib/hostname.js';
-
-vi.mock('node:os', () => ({
-  default: {hostname: vi.fn()},
-  hostname: vi.fn(),
-}));
-
-const mockHostname = vi.mocked(os.hostname);
 
 describe('sanitizeHostname', () => {
   it('lowercases and strips .local suffix', () => {
@@ -28,15 +20,13 @@ describe('sanitizeHostname', () => {
 });
 
 describe('buildProjectHostname', () => {
-  it('combines project slug with machine hostname', () => {
-    mockHostname.mockReturnValue('rasmus-macbook.local');
-    expect(buildProjectHostname('my-theme')).toBe('my-theme.rasmus-macbook.lvh.me');
+  it('uses the project slug directly under lvh.me', () => {
+    expect(buildProjectHostname('my-theme')).toBe('my-theme.lvh.me');
   });
 
-  it('builds phpmyadmin subdomain', () => {
-    mockHostname.mockReturnValue('rasmus-macbook.local');
+  it('builds a phpmyadmin subdomain', () => {
     expect(buildProjectHostname('my-theme', 'phpmyadmin')).toBe(
-      'phpmyadmin.my-theme.rasmus-macbook.lvh.me',
+      'phpmyadmin.my-theme.lvh.me',
     );
   });
 });

--- a/tests/lib/status.test.ts
+++ b/tests/lib/status.test.ts
@@ -10,13 +10,6 @@ import {
 } from '../../src/lib/status.js';
 import type {ProjectConfig} from '../../src/types/config.js';
 
-// buildProjectHostname embeds the machine hostname; pin it so URL assertions
-// are deterministic regardless of the host the test runs on.
-vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>();
-  return {...actual, default: {...actual, hostname: () => 'testbox'}};
-});
-
 const PROJECT: ProjectConfig = {
   project_id: 'proj-123',
   name: 'acme',
@@ -78,9 +71,9 @@ describe('getProjectStatus', () => {
       {name: 'proj-123-phpmyadmin', running: true},
     ]);
     expect(status.urls).toEqual({
-      site: 'http://acme.testbox.lvh.me:5477',
-      admin: 'http://acme.testbox.lvh.me:5477/wp-admin',
-      phpmyadmin: 'http://phpmyadmin.acme.testbox.lvh.me:5477',
+      site: 'http://acme.lvh.me:5477',
+      admin: 'http://acme.lvh.me:5477/wp-admin',
+      phpmyadmin: 'http://phpmyadmin.acme.lvh.me:5477',
     });
   });
 


### PR DESCRIPTION
## Why

`lvh.me` always resolves to `127.0.0.1`, so the per-machine segment in project hostnames added no value — it just made local URLs noisy and annoying to type or copy/paste-rewrite.

```
before:  http://my-theme.rasmus-macbook.lvh.me:5477
after:   http://my-theme.lvh.me:5477
```

## Change
- `buildProjectHostname` now returns `<slug>.lvh.me` (and `<subdomain>.<slug>.lvh.me` for phpMyAdmin).
- `getMachineHostname` is **kept** — it's still used to record the originating host on database backups, which is legitimately useful provenance.
- Updated `hostname` and `status` tests; dropped the now-unnecessary `os.hostname` mocking.

All four gates green: lint, typecheck, 194 tests, build.

Note: the README still shows the old format — I'll update that in the pending README PR (#26) so the two stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)