### PR TITLE
feat: catch outgoing email with Mailpit (kiqr open mail)

### DIFF
--- a/src/commands/open.tsx
+++ b/src/commands/open.tsx
@@ -25,6 +25,7 @@ export const args = zod.tuple([
           '  wp, wordpress, web        Open the site\n' +
           '  admin, wpadmin, dashboard  Open the WordPress dashboard (auto-login)\n' +
           '  phpmyadmin, pma            Open phpMyAdmin (auto-login)\n' +
+          '  mail, mailpit              Open the Mailpit email catcher\n' +
           '  plugins                    Open the plugins folder\n' +
           '  uploads, media             Open the uploads folder\n' +
           '  data                       Open the Kiqr project data folder',
@@ -42,6 +43,8 @@ const ALIASES: Record<string, string> = {
   web: 'wp',
   phpmyadmin: 'phpmyadmin',
   pma: 'phpmyadmin',
+  mail: 'mail',
+  mailpit: 'mail',
   admin: 'admin',
   wpadmin: 'admin',
   dashboard: 'admin',
@@ -109,6 +112,11 @@ export default function Open({args}: Props) {
           break;
         case 'phpmyadmin':
           openTarget(`http://${phpMyAdminHostname}:5477`);
+          break;
+        case 'mail':
+          // Mailpit is an agent-level service shared by every project, reached
+          // at a fixed host rather than a per-project hostname.
+          openTarget('http://mail.lvh.me:5477');
           break;
         case 'admin':
           if (lc?.login_secret) {

--- a/src/commands/restart.tsx
+++ b/src/commands/restart.tsx
@@ -5,6 +5,7 @@ import {useRef, useState} from 'react';
 import type {Step} from '../components/StepRunner.js';
 import StepRunner from '../components/StepRunner.js';
 import {ensureAgentRunning} from '../lib/agent.js';
+import {writeApacheConf} from '../lib/apache-conf.js';
 import {writeProjectCompose} from '../lib/compose.js';
 import {readLocalConfig, readProjectConfig, writeLocalConfig} from '../lib/config.js';
 import {
@@ -16,7 +17,6 @@ import {
 import {buildProjectHostname} from '../lib/hostname.js';
 import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
-import {writeApacheConf} from '../lib/apache-conf.js';
 import {
   getProjectPluginsDir,
   getProjectRuntimeDir,

--- a/src/commands/up.tsx
+++ b/src/commands/up.tsx
@@ -7,6 +7,7 @@ import {useRef, useState} from 'react';
 import type {Step} from '../components/StepRunner.js';
 import StepRunner from '../components/StepRunner.js';
 import {ensureAgentRunning} from '../lib/agent.js';
+import {writeApacheConf} from '../lib/apache-conf.js';
 import {writeProjectCompose} from '../lib/compose.js';
 import {
   projectConfigExists,
@@ -24,7 +25,6 @@ import {
 import {buildProjectHostname} from '../lib/hostname.js';
 import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
-import {writeApacheConf} from '../lib/apache-conf.js';
 import {
   getProjectPluginsDir,
   getProjectRuntimeDir,

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -26,10 +26,19 @@ export const KIQR_NETWORK = 'kiqr';
 export const AGENT_PROJECT = 'kiqr-agent';
 export const AGENT_PORT = 5477;
 
-export const AGENT_CONTAINERS = ['kiqr-traefik', 'kiqr-splash'] as const;
+export const AGENT_CONTAINERS = ['kiqr-traefik', 'kiqr-splash', 'kiqr-mailpit'] as const;
 
 const TRAEFIK_CONTAINER = 'kiqr-traefik';
 const SPLASH_CONTAINER = 'kiqr-splash';
+const MAILPIT_CONTAINER = 'kiqr-mailpit';
+
+/**
+ * Mailpit catches every outgoing email from any kiqr project (WordPress is
+ * pointed at it over SMTP via the per-project mu-plugin) and exposes a web UI
+ * at `mail.lvh.me`. It listens for SMTP on 1025 and serves its web UI on 8025.
+ */
+const MAILPIT_HOST = 'mail.lvh.me';
+const MAILPIT_WEB_PORT = 8025;
 
 export interface AgentStatus {
   running: boolean;
@@ -87,6 +96,18 @@ export function generateAgentCompose(agentDir: string): string {
           'traefik.http.routers.kiqr-splash.entrypoints=web',
           'traefik.http.routers.kiqr-splash.priority=1',
           'traefik.http.services.kiqr-splash.loadbalancer.server.port=80',
+        ],
+        networks: [KIQR_NETWORK],
+        restart: 'unless-stopped',
+      },
+      mailpit: {
+        image: 'axllent/mailpit:v1.30.1',
+        container_name: MAILPIT_CONTAINER,
+        labels: [
+          'traefik.enable=true',
+          `traefik.http.routers.kiqr-mailpit.rule=Host(\`${MAILPIT_HOST}\`)`,
+          'traefik.http.routers.kiqr-mailpit.entrypoints=web',
+          `traefik.http.services.kiqr-mailpit.loadbalancer.server.port=${MAILPIT_WEB_PORT}`,
         ],
         networks: [KIQR_NETWORK],
         restart: 'unless-stopped',

--- a/src/lib/mu-plugin.ts
+++ b/src/lib/mu-plugin.ts
@@ -76,6 +76,19 @@ add_action('init', function () {
     }
 }, 0);
 
+// Route all outgoing mail to the kiqr agent's Mailpit catcher over SMTP.
+// The WordPress container shares the kiqr network, so it resolves the
+// "kiqr-mailpit" container by name. Mailpit accepts unauthenticated,
+// unencrypted SMTP on port 1025.
+add_action('phpmailer_init', function ($phpmailer) {
+    $phpmailer->isSMTP();
+    $phpmailer->Host = 'kiqr-mailpit';
+    $phpmailer->Port = 1025;
+    $phpmailer->SMTPAuth = false;
+    $phpmailer->SMTPSecure = '';
+    $phpmailer->SMTPAutoTLS = false;
+});
+
 // Inject LiveReload script in development.
 //
 // The script src points at http://localhost on the host machine, which is only

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -21,8 +21,7 @@ export const SHARE_URL_CONTAINER_PATH = '/tmp/kiqr-share-url';
 export function resolveProjectContainerId(
   projectId: string,
   service: string,
-  exec: (cmd: string) => string = (cmd) =>
-    execSync(cmd, {stdio: 'pipe'}).toString(),
+  exec: (cmd: string) => string = (cmd) => execSync(cmd, {stdio: 'pipe'}).toString(),
 ): string | null {
   try {
     const out = exec(
@@ -126,13 +125,13 @@ export function writeShareUrlToContainer(
   }
   const id = resolveProjectContainerId(projectId, 'wordpress');
   if (!id) {
-    onError?.(new Error(`Could not resolve WordPress container for project ${projectId}`));
+    onError?.(
+      new Error(`Could not resolve WordPress container for project ${projectId}`),
+    );
     return;
   }
   try {
-    exec(
-      `docker exec ${id} sh -c 'printf %s ${url} > ${SHARE_URL_CONTAINER_PATH}'`,
-    );
+    exec(`docker exec ${id} sh -c 'printf %s ${url} > ${SHARE_URL_CONTAINER_PATH}'`);
   } catch (err) {
     onError?.(err);
   }

--- a/src/providers/BitnamiRuntimeProvider.ts
+++ b/src/providers/BitnamiRuntimeProvider.ts
@@ -81,15 +81,15 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         "$$fwd_host = !empty($$_SERVER['HTTP_X_FORWARDED_HOST']) ? trim(explode(',', $$_SERVER['HTTP_X_FORWARDED_HOST'])[0]) : ''; " +
         "$$fwd_proto = !empty($$_SERVER['HTTP_X_FORWARDED_PROTO']) ? strtolower(trim(explode(',', $$_SERVER['HTTP_X_FORWARDED_PROTO'])[0])) : ''; " +
         "$$share_url = ($$fwd_proto === 'https' && is_readable('/tmp/kiqr-share-url')) ? trim(@file_get_contents('/tmp/kiqr-share-url')) : ''; " +
-        "$$share_parts = $$share_url ? parse_url($$share_url) : false; " +
+        '$$share_parts = $$share_url ? parse_url($$share_url) : false; ' +
         "if (is_array($$share_parts) && !empty($$share_parts['host'])) { " +
         "  $$host = $$share_parts['host']; " +
         "  $$proto = strtolower($$share_parts['scheme'] ?? 'https'); " +
         "  $$_SERVER['HTTP_HOST'] = $$host; " +
-        "} else { " +
+        '} else { ' +
         "  $$host = $$fwd_host ?: ($$_SERVER['HTTP_HOST'] ?? 'localhost'); " +
         "  $$proto = ($$fwd_proto === 'https') ? 'https' : 'http'; " +
-        "} " +
+        '} ' +
         "if ($$proto === 'https') { $$_SERVER['HTTPS'] = 'on'; $$_SERVER['SERVER_PORT'] = 443; } " +
         "define('WP_HOME', $$proto . '://' . $$host); " +
         "define('WP_SITEURL', $$proto . '://' . $$host);",

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -62,9 +62,7 @@ describe('generateAgentCompose', () => {
     const parsed = YAML.parse(yaml);
     const command = parsed.services.traefik.command as string[];
     expect(
-      command.some(
-        (c) => c === '--entrypoints.web.forwardedHeaders.insecure=true',
-      ),
+      command.some((c) => c === '--entrypoints.web.forwardedHeaders.insecure=true'),
     ).toBe(true);
   });
 
@@ -75,6 +73,30 @@ describe('generateAgentCompose', () => {
     expect(parsed.services.splash.image).toBe('nginx:1.30-alpine');
     const labels = parsed.services.splash.labels;
     expect(labels.some((l: string) => l.includes('priority=1'))).toBe(true);
+  });
+
+  it('includes the Mailpit email catcher with a pinned image', () => {
+    const yaml = generateAgentCompose('/tmp/kiqr/agent');
+    const parsed = YAML.parse(yaml);
+    expect(parsed.services.mailpit).toBeDefined();
+    expect(parsed.services.mailpit.image).toBe('axllent/mailpit:v1.30.1');
+    expect(parsed.services.mailpit.container_name).toBe('kiqr-mailpit');
+    expect(parsed.services.mailpit.networks).toContain('kiqr');
+    expect(parsed.services.mailpit.restart).toBe('unless-stopped');
+  });
+
+  it('routes mail.lvh.me to the Mailpit web UI on port 8025', () => {
+    const yaml = generateAgentCompose('/tmp/kiqr/agent');
+    const parsed = YAML.parse(yaml);
+    const labels: string[] = parsed.services.mailpit.labels;
+    expect(labels).toContain('traefik.enable=true');
+    expect(labels).toContain(
+      'traefik.http.routers.kiqr-mailpit.rule=Host(`mail.lvh.me`)',
+    );
+    expect(labels).toContain('traefik.http.routers.kiqr-mailpit.entrypoints=web');
+    expect(labels).toContain(
+      'traefik.http.services.kiqr-mailpit.loadbalancer.server.port=8025',
+    );
   });
 });
 

--- a/tests/lib/mu-plugin.test.ts
+++ b/tests/lib/mu-plugin.test.ts
@@ -101,7 +101,7 @@ describe('writeMuPlugin', () => {
     // production concern; in dev we want pages to render wherever requested.
     const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
     expect(content).toContain("remove_filter('template_redirect', 'redirect_canonical')");
-    expect(content).toContain("WPSEO_Frontend");
+    expect(content).toContain('WPSEO_Frontend');
   });
 
   it('rewrites absolute production URLs in the response body to the current dynamic URL', () => {
@@ -119,6 +119,15 @@ describe('writeMuPlugin', () => {
     expect(content).toContain('str_replace($patterns, WP_HOME, $buf)');
     // Bails out on binary responses (images served via PHP, downloads, etc.).
     expect(content).toContain('Content-Type:');
+  });
+
+  it('routes outgoing mail to the kiqr-mailpit SMTP catcher via phpmailer_init', () => {
+    const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
+    expect(content).toContain("add_action('phpmailer_init'");
+    expect(content).toContain('$phpmailer->isSMTP()');
+    expect(content).toContain("$phpmailer->Host = 'kiqr-mailpit'");
+    expect(content).toContain('$phpmailer->Port = 1025');
+    expect(content).toContain('$phpmailer->SMTPAuth = false');
   });
 
   it('is deterministic across writes', () => {

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -150,7 +150,7 @@ describe('writeShareUrlToContainer', () => {
 });
 
 describe('clearShareUrlFromContainer', () => {
-  it('is a no-op when no matching container is running (doesn\'t throw)', () => {
+  it("is a no-op when no matching container is running (doesn't throw)", () => {
     // Same rationale as writeShareUrlToContainer: when the container is
     // already gone there is nothing to clean and we mustn't fail the
     // tunnel-exit path.


### PR DESCRIPTION
## What

Adds an **agent-level Mailpit email catcher** so outgoing mail from any kiqr project is captured locally instead of being delivered for real, plus a `kiqr open mail` shortcut to view it.

### Agent compose (`src/lib/agent.ts`)
- New `mailpit` service using `axllent/mailpit:v1.30.1` (tag verified to exist via the Docker Hub registry API), `container_name: kiqr-mailpit`, on `KIQR_NETWORK`, `restart: unless-stopped`.
- Traefik labels mirror the existing splash pattern: `Host(\`mail.lvh.me\`)` on entrypoint `web`, loadbalancer server port `8025` (Mailpit's web UI). Mailpit also listens for SMTP on `1025` for in-network clients.
- `kiqr-mailpit` is added to `AGENT_CONTAINERS`, so it shows up in `kiqr agent status`.

### WordPress mail routing (`src/lib/mu-plugin.ts`)
- Adds a `phpmailer_init` hook that points PHPMailer at SMTP host `kiqr-mailpit`, port `1025`, no auth, no encryption. The WordPress container shares `KIQR_NETWORK`, so it resolves `kiqr-mailpit` by name.
- Existing auto-login + LiveReload behavior is unchanged.

### `kiqr open mail` (`src/commands/open.tsx`)
- New `mail` / `mailpit` target that opens `http://mail.lvh.me:5477`, following the existing open-target pattern.

## Applying the change
Because this touches both the agent stack and the per-project mu-plugin, after pulling this in you need to:
- `kiqr agent restart` — to bring up the new `kiqr-mailpit` container and Traefik route.
- `kiqr restart` (per project) — to re-write the mu-plugin so WordPress starts routing mail to Mailpit.

## Tests
- Agent compose: asserts the `mailpit` service image, `kiqr-mailpit` container name, network, restart policy, and the Traefik Host/entrypoint/port labels.
- mu-plugin: asserts the `phpmailer_init` SMTP routing hook (`isSMTP`, host `kiqr-mailpit`, port `1025`, `SMTPAuth=false`).

All four gates pass locally: `typecheck`, `test` (210 passed), `build`, `lint`.

## Not verified
- **Live SMTP capture was not verified** — there is no Docker daemon in this environment, so I could not actually boot Mailpit + WordPress and confirm a real email lands in the Mailpit inbox. Generation logic is covered by unit tests; the end-to-end SMTP path (DNS resolution of `kiqr-mailpit`, Traefik routing of `mail.lvh.me`, PHPMailer delivery) was validated only by inspection.

## Docs
README documentation for `kiqr open mail` and the mail catcher will follow — a separate README rewrite PR is currently open, so this PR intentionally leaves README.md untouched. cc @kjellberg

🤖 Generated with [Claude Code](https://claude.com/claude-code)