### PR TITLE
chore: fix lint failures on main (biome format)

### DIFF
--- a/src/commands/restart.tsx
+++ b/src/commands/restart.tsx
@@ -5,6 +5,7 @@ import {useRef, useState} from 'react';
 import type {Step} from '../components/StepRunner.js';
 import StepRunner from '../components/StepRunner.js';
 import {ensureAgentRunning} from '../lib/agent.js';
+import {writeApacheConf} from '../lib/apache-conf.js';
 import {writeProjectCompose} from '../lib/compose.js';
 import {readLocalConfig, readProjectConfig, writeLocalConfig} from '../lib/config.js';
 import {
@@ -16,7 +17,6 @@ import {
 import {buildProjectHostname} from '../lib/hostname.js';
 import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
-import {writeApacheConf} from '../lib/apache-conf.js';
 import {
   getProjectPluginsDir,
   getProjectRuntimeDir,

--- a/src/commands/up.tsx
+++ b/src/commands/up.tsx
@@ -7,6 +7,7 @@ import {useRef, useState} from 'react';
 import type {Step} from '../components/StepRunner.js';
 import StepRunner from '../components/StepRunner.js';
 import {ensureAgentRunning} from '../lib/agent.js';
+import {writeApacheConf} from '../lib/apache-conf.js';
 import {writeProjectCompose} from '../lib/compose.js';
 import {
   projectConfigExists,
@@ -24,7 +25,6 @@ import {
 import {buildProjectHostname} from '../lib/hostname.js';
 import {validateWordPressPhp} from '../lib/image-tags.js';
 import {writeMuPlugin} from '../lib/mu-plugin.js';
-import {writeApacheConf} from '../lib/apache-conf.js';
 import {
   getProjectPluginsDir,
   getProjectRuntimeDir,

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -21,8 +21,7 @@ export const SHARE_URL_CONTAINER_PATH = '/tmp/kiqr-share-url';
 export function resolveProjectContainerId(
   projectId: string,
   service: string,
-  exec: (cmd: string) => string = (cmd) =>
-    execSync(cmd, {stdio: 'pipe'}).toString(),
+  exec: (cmd: string) => string = (cmd) => execSync(cmd, {stdio: 'pipe'}).toString(),
 ): string | null {
   try {
     const out = exec(
@@ -126,13 +125,13 @@ export function writeShareUrlToContainer(
   }
   const id = resolveProjectContainerId(projectId, 'wordpress');
   if (!id) {
-    onError?.(new Error(`Could not resolve WordPress container for project ${projectId}`));
+    onError?.(
+      new Error(`Could not resolve WordPress container for project ${projectId}`),
+    );
     return;
   }
   try {
-    exec(
-      `docker exec ${id} sh -c 'printf %s ${url} > ${SHARE_URL_CONTAINER_PATH}'`,
-    );
+    exec(`docker exec ${id} sh -c 'printf %s ${url} > ${SHARE_URL_CONTAINER_PATH}'`);
   } catch (err) {
     onError?.(err);
   }

--- a/src/providers/BitnamiRuntimeProvider.ts
+++ b/src/providers/BitnamiRuntimeProvider.ts
@@ -81,15 +81,15 @@ export class BitnamiRuntimeProvider implements RuntimeProvider {
         "$$fwd_host = !empty($$_SERVER['HTTP_X_FORWARDED_HOST']) ? trim(explode(',', $$_SERVER['HTTP_X_FORWARDED_HOST'])[0]) : ''; " +
         "$$fwd_proto = !empty($$_SERVER['HTTP_X_FORWARDED_PROTO']) ? strtolower(trim(explode(',', $$_SERVER['HTTP_X_FORWARDED_PROTO'])[0])) : ''; " +
         "$$share_url = ($$fwd_proto === 'https' && is_readable('/tmp/kiqr-share-url')) ? trim(@file_get_contents('/tmp/kiqr-share-url')) : ''; " +
-        "$$share_parts = $$share_url ? parse_url($$share_url) : false; " +
+        '$$share_parts = $$share_url ? parse_url($$share_url) : false; ' +
         "if (is_array($$share_parts) && !empty($$share_parts['host'])) { " +
         "  $$host = $$share_parts['host']; " +
         "  $$proto = strtolower($$share_parts['scheme'] ?? 'https'); " +
         "  $$_SERVER['HTTP_HOST'] = $$host; " +
-        "} else { " +
+        '} else { ' +
         "  $$host = $$fwd_host ?: ($$_SERVER['HTTP_HOST'] ?? 'localhost'); " +
         "  $$proto = ($$fwd_proto === 'https') ? 'https' : 'http'; " +
-        "} " +
+        '} ' +
         "if ($$proto === 'https') { $$_SERVER['HTTPS'] = 'on'; $$_SERVER['SERVER_PORT'] = 443; } " +
         "define('WP_HOME', $$proto . '://' . $$host); " +
         "define('WP_SITEURL', $$proto . '://' . $$host);",

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -62,9 +62,7 @@ describe('generateAgentCompose', () => {
     const parsed = YAML.parse(yaml);
     const command = parsed.services.traefik.command as string[];
     expect(
-      command.some(
-        (c) => c === '--entrypoints.web.forwardedHeaders.insecure=true',
-      ),
+      command.some((c) => c === '--entrypoints.web.forwardedHeaders.insecure=true'),
     ).toBe(true);
   });
 

--- a/tests/lib/mu-plugin.test.ts
+++ b/tests/lib/mu-plugin.test.ts
@@ -101,7 +101,7 @@ describe('writeMuPlugin', () => {
     // production concern; in dev we want pages to render wherever requested.
     const content = fs.readFileSync(writeMuPlugin(tmp), 'utf-8');
     expect(content).toContain("remove_filter('template_redirect', 'redirect_canonical')");
-    expect(content).toContain("WPSEO_Frontend");
+    expect(content).toContain('WPSEO_Frontend');
   });
 
   it('rewrites absolute production URLs in the response body to the current dynamic URL', () => {

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -150,7 +150,7 @@ describe('writeShareUrlToContainer', () => {
 });
 
 describe('clearShareUrlFromContainer', () => {
-  it('is a no-op when no matching container is running (doesn\'t throw)', () => {
+  it("is a no-op when no matching container is running (doesn't throw)", () => {
     // Same rationale as writeShareUrlToContainer: when the container is
     // already gone there is nothing to clean and we mustn't fail the
     // tunnel-exit path.


### PR DESCRIPTION
## Why

`main` is currently **failing the lint CI gate**. The recent tunnel/share + Apache-conf work was pushed without running `biome format`, leaving 7 files un-formatted:

`up.tsx`, `restart.tsx`, `share.ts`, `BitnamiRuntimeProvider.ts`, `share.test.ts`, `agent.test.ts`, `mu-plugin.test.ts`.

## What

Ran `npm run format` (`biome check --write .`). **Pure formatting + import-organization — zero behavior changes.**

## Verified
- `npm run lint` → clean (84 files)
- `npm run typecheck` → pass
- `npm test` → 224 passed
- `npm run build` → success

Merging this restores a green lint gate for main and unblocks every open PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)